### PR TITLE
Update for SignalFx configuration and testing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -384,14 +384,13 @@ Options can be configured as a parameter to the [init()](https://datadog.github.
 
 | Config        | Environment Variable         | Default   | Description |
 | ------------- | ---------------------------- | --------- | ----------- |
-| enabled       | DD_TRACE_ENABLED             | true      | Whether to enable the tracer. |
-| debug         | DD_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
-| service       | DD_SERVICE_NAME              |           | The service name to be used for this program. |
-| url           | DD_TRACE_AGENT_URL           |           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
-| hostname      | DD_TRACE_AGENT_HOSTNAME      | localhost | The address of the trace agent that the tracer will submit to. |
-| port          | DD_TRACE_AGENT_PORT          | 8126      | The port of the trace agent that the tracer will submit to. |
-| env           | DD_ENV                       |           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection  | DD_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries.
+| enabled       | SIGNALFX_TRACE_ENABLED             | true      | Whether to enable the tracer. |
+| debug         | SIGNALFX_TRACE_DEBUG               | false     | Enable debug logging in the tracer. |
+| service       | SIGNALFX_SERVICE_NAME              |           | The service name to be used for this program. |
+| url           | SIGNALFX_TRACE_AGENT_URL           |           | The url of the Agent or Gateway that the tracer will submit to. Takes priority over hostname and port, if set. |
+| hostname      | SIGNALFX_TRACE_AGENT_HOSTNAME      | localhost | The address of the Agent or Gateway that the tracer will submit to. |
+| port          | SIGNALFX_TRACE_AGENT_PORT          | 8126      | The port of the Agent or Gateway that the tracer will submit to. |
+| logInjection  | SIGNALFX_LOGS_INJECTION            | false     | Enable automatic injection of trace IDs in logs for supported logging libraries.
 | tags          |                              | {}        | Set global tags that should be applied to all spans. |
 | sampleRate    |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |

--- a/src/config.js
+++ b/src/config.js
@@ -8,19 +8,19 @@ class Config {
   constructor (service, options) {
     options = typeof service === 'object' ? service : options || {}
 
-    const enabled = coalesce(options.enabled, platform.env('DD_TRACE_ENABLED'), true)
-    const debug = coalesce(options.debug, platform.env('DD_TRACE_DEBUG'), false)
-    const logInjection = coalesce(options.logInjection, platform.env('DD_LOGS_INJECTION'), false)
-    const env = coalesce(options.env, platform.env('DD_ENV'))
-    const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), null)
+    const enabled = coalesce(options.enabled, platform.env('SIGNALFX_TRACE_ENABLED'), true)
+    const debug = coalesce(options.debug, platform.env('SIGNALFX_TRACE_DEBUG'), false)
+    const logInjection = coalesce(options.logInjection, platform.env('SIGNALFX_LOGS_INJECTION'), false)
+    const env = coalesce(options.env, platform.env('SIGNALFX_ENV'))
+    const url = coalesce(options.url, platform.env('SIGNALFX_TRACE_AGENT_URL'), null)
     const protocol = 'http'
     const hostname = coalesce(
       options.hostname,
-      platform.env('DD_AGENT_HOST'),
-      platform.env('DD_TRACE_AGENT_HOSTNAME'),
+      platform.env('SIGNALFX_AGENT_HOST'),
+      platform.env('SIGNALFX_TRACE_AGENT_HOSTNAME'),
       'localhost'
     )
-    const port = coalesce(options.port, platform.env('DD_TRACE_AGENT_PORT'), 8126)
+    const port = coalesce(options.port, platform.env('SIGNALFX_TRACE_AGENT_PORT'), 9080)
     const zipkin = coalesce(options.zipkin, true)
     const path = coalesce(options.path, '/api/v2/spans')
     const headers = coalesce(options.headers, {})
@@ -42,7 +42,7 @@ class Config {
     this.sampleRate = sampleRate
     this.logger = options.logger
     this.plugins = !!plugins
-    this.service = coalesce(options.service, platform.env('DD_SERVICE_NAME'), service, 'node')
+    this.service = coalesce(options.service, platform.env('SIGNALFX_SERVICE_NAME'), service, 'node')
   }
 }
 

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -11,7 +11,7 @@ class NoopTracer extends Tracer {
 
     let ScopeManager
 
-    if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+    if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') {
       ScopeManager = require('../scope/noop/scope_manager')
     } else {
       ScopeManager = require('../scope/scope_manager')

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -46,6 +46,7 @@ class DatadogTracer extends Tracer {
       [formats.BINARY]: new BinaryPropagator(),
       [formats.LOG]: new LogPropagator()
     }
+
     if (config.zipkin) {
       this._propagators[formats.TEXT_MAP] = new B3TextMapPropagator()
       this._propagators[formats.HTTP_HEADERS] = new B3TextMapPropagator()

--- a/src/plugins/amqp10.js
+++ b/src/plugins/amqp10.js
@@ -82,7 +82,7 @@ function addTags (tracer, config, span, link) {
 
   span.addTags({
     'service.name': config.service || `${tracer._service}-amqp`,
-    'span.type': 'worker',
+    'component': 'amqp10',
     'amqp.link.name': link.name,
     'amqp.link.handle': link.handle,
     'amqp.connection.host': address.host,

--- a/src/plugins/amqplib.js
+++ b/src/plugins/amqplib.js
@@ -99,7 +99,7 @@ function addTags (channel, tracer, config, span, method, fields) {
   span.addTags({
     'service.name': config.service || `${tracer._service}-amqp`,
     'resource.name': getResourceName(method, fields),
-    'span.type': 'worker'
+    'component': 'amqplib'
   })
 
   if (channel.connection && channel.connection.stream) {

--- a/src/plugins/express.js
+++ b/src/plugins/express.js
@@ -8,7 +8,8 @@ function createWrapMethod (tracer, config) {
   config = web.normalizeConfig(config)
 
   function ddTrace (req, res, next) {
-    web.instrument(tracer, config, req, res, 'express.request')
+    const span = web.instrument(tracer, config, req, res, 'express.request')
+    span.setTag('component', 'express')
 
     next()
   }

--- a/src/plugins/hapi.js
+++ b/src/plugins/hapi.js
@@ -9,14 +9,14 @@ function createWrapGenerate (tracer, config) {
     return function generateWithTrace (server, req, res, options) {
       let request
 
-      web.instrument(tracer, config, req, res, 'hapi.request', () => {
+      const span = web.instrument(tracer, config, req, res, 'hapi.request', () => {
         request = generate.apply(this, arguments)
 
         web.beforeEnd(req, () => {
           web.enterRoute(req, request.route.path)
         })
       })
-
+      span.setTag('component', 'hapi')
       return request
     }
   }
@@ -32,14 +32,14 @@ function createWrapExecute (tracer, config) {
 
       let returnValue
 
-      web.instrument(tracer, config, req, res, 'hapi.request', () => {
+      const span = web.instrument(tracer, config, req, res, 'hapi.request', () => {
         returnValue = execute.apply(this, arguments)
 
         web.beforeEnd(req, () => {
           web.enterRoute(req, this.route.path)
         })
       })
-
+      span.setTag('component', 'hapi')
       return returnValue
     }
   }

--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -33,7 +33,7 @@ function patch (http, methodName, tracer, config) {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': getServiceName(tracer, config, options),
           'resource.name': method,
-          'span.type': 'web',
+          'span.type': 'http',
           'http.method': method,
           'http.url': uri
         }

--- a/src/plugins/koa.js
+++ b/src/plugins/koa.js
@@ -6,7 +6,8 @@ function createWrapUse (tracer, config) {
   config = web.normalizeConfig(config)
 
   function ddTrace (ctx, next) {
-    web.instrument(tracer, config, ctx.req, ctx.res, 'koa.request')
+    const span = web.instrument(tracer, config, ctx.req, ctx.res, 'koa.request')
+    span.setTag('component', 'koa')
 
     return next()
   }

--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -12,7 +12,7 @@ function createWrapQuery (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-mysql`,
-          'span.type': 'sql',
+          'span.type': 'mysql',
           'db.type': 'mysql',
           'db.user': this.config.user,
           'out.host': this.config.host,

--- a/src/plugins/mysql2.js
+++ b/src/plugins/mysql2.js
@@ -12,7 +12,7 @@ function createWrapQuery (tracer, config) {
         tags: {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-mysql`,
-          'span.type': 'sql',
+          'component': 'mysql2',
           'db.type': 'mysql',
           'db.user': this.config.user,
           'out.host': this.config.host,

--- a/src/plugins/pg.js
+++ b/src/plugins/pg.js
@@ -26,7 +26,7 @@ function patch (pg, tracer, config) {
           [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
           'service.name': config.service || `${tracer._service}-postgres`,
           'resource.name': statement,
-          'span.type': 'sql',
+          'component': 'pg',
           'db.type': 'postgres'
         }
       })

--- a/src/plugins/restify.js
+++ b/src/plugins/restify.js
@@ -9,7 +9,8 @@ function createWrapSetupRequest (tracer, config) {
 
   return function wrapSetupRequest (setupRequest) {
     return function setupRequestWithTrace (req, res) {
-      web.instrument(tracer, config, req, res, 'restify.request')
+      const span = web.instrument(tracer, config, req, res, 'restify.request')
+      span.setTag('component', 'restify')
       web.beforeEnd(req, () => {
         if (req.route) {
           web.enterRoute(req, req.route.path)

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -112,7 +112,10 @@ function wrapDone (original, req) {
 }
 
 function callHandle (layer, handle, req, args) {
-  web.enterMiddleware(req, handle, 'express.middleware')
+  const span = web.enterMiddleware(req, handle, 'express.middleware')
+  if (span) {
+    span.setTag('component', 'express')
+  }
 
   try {
     return handle.apply(layer, args)

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -8,7 +8,7 @@ class DatadogTracer extends Tracer {
 
     let ScopeManager
 
-    if (process.env.DD_CONTEXT_PROPAGATION === 'false') {
+    if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') {
       ScopeManager = require('./scope/noop/scope_manager')
     } else {
       ScopeManager = require('./scope/scope_manager')

--- a/src/zipkin/format.js
+++ b/src/zipkin/format.js
@@ -51,6 +51,10 @@ function formatTags (formatted, span) {
         }
         break
       case 'span.type':
+        if (formattedTags.component === undefined) {
+          formattedTags.component = String(tags[tag])
+        }
+        break
       case 'service.name':
         break // do not add to tags
       case 'resource.name':

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -22,7 +22,7 @@ describe('Config', () => {
     expect(config).to.have.property('debug', false)
     expect(config).to.have.nested.property('url.protocol', 'http:')
     expect(config).to.have.nested.property('url.hostname', 'localhost')
-    expect(config).to.have.nested.property('url.port', '8126')
+    expect(config).to.have.nested.property('url.port', '9080')
     expect(config).to.have.property('flushInterval', 2000)
     expect(config).to.have.property('bufferSize', 100000)
     expect(config).to.have.property('sampleRate', 1)
@@ -38,12 +38,12 @@ describe('Config', () => {
   })
 
   it('should initialize from environment variables', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
-    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
-    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
-    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
-    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
-    platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('SIGNALFX_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('SIGNALFX_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('SIGNALFX_SERVICE_NAME').returns('service')
+    platform.env.withArgs('SIGNALFX_ENV').returns('test')
 
     const config = new Config()
 
@@ -57,13 +57,13 @@ describe('Config', () => {
   })
 
   it('should initialize from environment variables with url taking precedence', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:7777')
-    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
-    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
-    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
-    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
-    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
-    platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_URL').returns('https://agent2:7777')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('SIGNALFX_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('SIGNALFX_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('SIGNALFX_SERVICE_NAME').returns('service')
+    platform.env.withArgs('SIGNALFX_ENV').returns('test')
 
     const config = new Config()
 
@@ -140,8 +140,8 @@ describe('Config', () => {
   })
 
   it('should give priority to the common agent environment variable', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('trace-agent')
-    platform.env.withArgs('DD_AGENT_HOST').returns('agent')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_HOSTNAME').returns('trace-agent')
+    platform.env.withArgs('SIGNALFX_AGENT_HOST').returns('agent')
 
     const config = new Config()
 
@@ -149,13 +149,13 @@ describe('Config', () => {
   })
 
   it('should give priority to the options', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('https://agent2:6218')
-    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
-    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
-    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
-    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
-    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
-    platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_URL').returns('https://agent2:6218')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('SIGNALFX_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('SIGNALFX_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('SIGNALFX_SERVICE_NAME').returns('service')
+    platform.env.withArgs('SIGNALFX_ENV').returns('test')
 
     const config = new Config({
       enabled: true,
@@ -177,13 +177,13 @@ describe('Config', () => {
   })
 
   it('should give priority to the options especially url', () => {
-    platform.env.withArgs('DD_TRACE_AGENT_URL').returns('http://agent2:6218')
-    platform.env.withArgs('DD_TRACE_AGENT_HOSTNAME').returns('agent')
-    platform.env.withArgs('DD_TRACE_AGENT_PORT').returns('6218')
-    platform.env.withArgs('DD_TRACE_ENABLED').returns('false')
-    platform.env.withArgs('DD_TRACE_DEBUG').returns('true')
-    platform.env.withArgs('DD_SERVICE_NAME').returns('service')
-    platform.env.withArgs('DD_ENV').returns('test')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_URL').returns('http://agent2:6218')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_HOSTNAME').returns('agent')
+    platform.env.withArgs('SIGNALFX_TRACE_AGENT_PORT').returns('6218')
+    platform.env.withArgs('SIGNALFX_TRACE_ENABLED').returns('false')
+    platform.env.withArgs('SIGNALFX_TRACE_DEBUG').returns('true')
+    platform.env.withArgs('SIGNALFX_SERVICE_NAME').returns('service')
+    platform.env.withArgs('SIGNALFX_ENV').returns('test')
 
     const config = new Config({
       enabled: true,

--- a/test/plugins/amqp10.spec.js
+++ b/test/plugins/amqp10.spec.js
@@ -68,10 +68,9 @@ describe('Plugin', () => {
               .use(traces => {
                 const span = traces[0][0]
 
-                expect(span).to.have.property('name', 'amqp.send')
-                expect(span).to.have.property('service', 'test-amqp')
-                expect(span).to.have.property('resource', 'send amq.topic')
-                expect(span).to.have.property('type', 'worker')
+                expect(span).to.have.property('name', 'send amq.topic')
+                expect(span).to.have.property('service', 'test')
+                expect(span.meta).to.have.property('component', 'amqp10')
                 expect(span.meta).to.have.property('span.kind', 'producer')
                 expect(span.meta).to.have.property('out.host', 'localhost')
                 expect(span.meta).to.have.property('out.port', '5673')
@@ -96,7 +95,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const span = traces[0][0]
 
-                expect(span.error).to.equal(1)
+                expect(span.meta).to.have.property('error', true)
                 expect(span.meta).to.have.property('error.type', error.name)
                 expect(span.meta).to.have.property('error.msg', error.message)
                 expect(span.meta).to.have.property('error.stack', error.stack)
@@ -134,10 +133,9 @@ describe('Plugin', () => {
               .use(traces => {
                 const span = traces[0][0]
 
-                expect(span).to.have.property('name', 'amqp.receive')
-                expect(span).to.have.property('service', 'test-amqp')
-                expect(span).to.have.property('resource', 'receive amq.topic')
-                expect(span).to.have.property('type', 'worker')
+                expect(span).to.have.property('name', 'receive amq.topic')
+                expect(span).to.have.property('service', 'test')
+                expect(span.meta).to.have.property('component', 'amqp10')
                 expect(span.meta).to.have.property('span.kind', 'consumer')
                 expect(span.meta).to.have.property('amqp.connection.host', 'localhost')
                 expect(span.meta).to.have.property('amqp.connection.port', '5673')
@@ -154,7 +152,7 @@ describe('Plugin', () => {
           })
 
           it('should run the message event listener in the AMQP span scope', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             const parent = tracer.scopeManager().active()
 

--- a/test/plugins/amqplib.spec.js
+++ b/test/plugins/amqplib.spec.js
@@ -52,10 +52,9 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('name', 'amqp.command')
-                  expect(span).to.have.property('service', 'test-amqp')
-                  expect(span).to.have.property('resource', 'queue.declare test')
-                  expect(span).to.have.property('type', 'worker')
+                  expect(span).to.have.property('name', 'queue.declare test')
+                  expect(span).to.have.property('service', 'test')
+                  expect(span.meta).to.have.property('component', 'amqplib')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
                 }, 2)
@@ -70,10 +69,9 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('name', 'amqp.command')
-                  expect(span).to.have.property('service', 'test-amqp')
-                  expect(span).to.have.property('resource', 'queue.delete test')
-                  expect(span).to.have.property('type', 'worker')
+                  expect(span).to.have.property('name', 'queue.delete test')
+                  expect(span).to.have.property('service', 'test')
+                  expect(span.meta).to.have.property('component', 'amqplib')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
                 }, 3)
@@ -91,7 +89,7 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('error', 1)
+                  expect(span.meta).to.have.property('error', true)
                   expect(span.meta).to.have.property('error.type', error.name)
                   expect(span.meta).to.have.property('error.msg', error.message)
                   expect(span.meta).to.have.property('error.stack', error.stack)
@@ -113,10 +111,9 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('name', 'amqp.command')
-                  expect(span).to.have.property('service', 'test-amqp')
-                  expect(span).to.have.property('resource', 'basic.publish exchange routingKey')
-                  expect(span).to.have.property('type', 'worker')
+                  expect(span).to.have.property('name', 'basic.publish exchange routingKey')
+                  expect(span).to.have.property('service', 'test')
+                  expect(span.meta).to.have.property('component', 'amqplib')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
                   expect(span.meta).to.have.property('span.kind', 'producer')
@@ -136,7 +133,7 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('error', 1)
+                  expect(span.meta).to.have.property('error', true)
                   expect(span.meta).to.have.property('error.type', error.name)
                   expect(span.meta).to.have.property('error.msg', error.message)
                   expect(span.meta).to.have.property('error.stack', error.stack)
@@ -161,10 +158,9 @@ describe('Plugin', () => {
                 .use(traces => {
                   const span = traces[0][0]
 
-                  expect(span).to.have.property('name', 'amqp.command')
-                  expect(span).to.have.property('service', 'test-amqp')
-                  expect(span).to.have.property('resource', `basic.deliver ${queue}`)
-                  expect(span).to.have.property('type', 'worker')
+                  expect(span).to.have.property('name', `basic.deliver ${queue}`)
+                  expect(span).to.have.property('service', 'test')
+                  expect(span.meta).to.have.property('component', 'amqplib')
                   expect(span.meta).to.have.property('out.host', 'localhost')
                   expect(span.meta).to.have.property('out.port', '5672')
                   expect(span.meta).to.have.property('span.kind', 'consumer')
@@ -265,7 +261,7 @@ describe('Plugin', () => {
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
-              expect(traces[0][0]).to.have.property('resource', 'queue.declare test')
+              expect(traces[0][0]).to.have.property('name', 'queue.declare test')
             }, 2)
             .then(done)
             .catch(done)

--- a/test/plugins/bluebird.spec.js
+++ b/test/plugins/bluebird.spec.js
@@ -28,7 +28,7 @@ describe('Plugin', () => {
         })
 
         it('should run the then() callback in context where then() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const promise = new Promise((resolve, reject) => {
@@ -53,7 +53,7 @@ describe('Plugin', () => {
         })
 
         it('should run the catch() callback in context where catch() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const promise = new Promise((resolve, reject) => {
@@ -79,7 +79,7 @@ describe('Plugin', () => {
         })
 
         it('should allow to run without a scope if not available when calling then()', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           tracer.scopeManager().activate(null)
 

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -48,7 +48,7 @@ describe('Plugin', () => {
         it('should sanitize the resource name', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('resource', 'POST /logstash-?.?.?/_search')
+              expect(traces[0][0]).to.have.property('name', 'POST /logstash-?.?.?/_search')
             })
             .then(done)
             .catch(done)
@@ -96,9 +96,9 @@ describe('Plugin', () => {
           it('should do automatic instrumentation', done => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('service', 'test-elasticsearch')
-                expect(traces[0][0]).to.have.property('resource', 'HEAD /')
-                expect(traces[0][0]).to.have.property('type', 'elasticsearch')
+                expect(traces[0][0]).to.have.property('service', 'test')
+                expect(traces[0][0]).to.have.property('name', 'HEAD /')
+                expect(traces[0][0].meta).to.have.property('component', 'elasticsearch')
               })
               .then(done)
               .catch(done)
@@ -107,7 +107,7 @@ describe('Plugin', () => {
           })
 
           it('should propagate context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             agent
               .use(traces => {
@@ -123,7 +123,7 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             client.ping(error => {
               expect(tracer.scopeManager().active()).to.be.null
@@ -159,9 +159,9 @@ describe('Plugin', () => {
           it('should do automatic instrumentation', done => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('service', 'test-elasticsearch')
-                expect(traces[0][0]).to.have.property('resource', 'HEAD /')
-                expect(traces[0][0]).to.have.property('type', 'elasticsearch')
+                expect(traces[0][0]).to.have.property('service', 'test')
+                expect(traces[0][0]).to.have.property('name', 'HEAD /')
+                expect(traces[0][0].meta).to.have.property('component', 'elasticsearch')
               })
               .then(done)
               .catch(done)
@@ -170,7 +170,7 @@ describe('Plugin', () => {
           })
 
           it('should propagate context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             agent
               .use(traces => {
@@ -188,7 +188,7 @@ describe('Plugin', () => {
           })
 
           it('should run resolved promises in the parent context', () => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
             return client.ping()
               .then(() => {
@@ -197,7 +197,7 @@ describe('Plugin', () => {
           })
 
           it('should run rejected promises in the parent context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             client.search({ index: 'invalid' })
               .catch(() => {

--- a/test/plugins/express.spec.js
+++ b/test/plugins/express.spec.js
@@ -50,8 +50,8 @@ describe('Plugin', () => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'http')
-                expect(spans[0]).to.have.property('resource', 'GET /user')
+                expect(spans[0].meta).to.have.property('component', 'express')
+                expect(spans[0]).to.have.property('name', 'GET /user')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
                 expect(spans[0].meta).to.have.property('http.method', 'GET')
@@ -84,8 +84,8 @@ describe('Plugin', () => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'http')
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0].meta).to.have.property('component', 'express')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)
                 expect(spans[0].meta).to.have.property('http.method', 'GET')
@@ -120,8 +120,8 @@ describe('Plugin', () => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
-                expect(spans[0]).to.have.property('type', 'http')
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0].meta).to.have.property('component', 'express')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
                 expect(spans[0].meta).to.have.property('span.kind', 'server')
                 expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/app/user/1`)
                 expect(spans[0].meta).to.have.property('http.method', 'GET')
@@ -156,17 +156,17 @@ describe('Plugin', () => {
 
                 expect(spans).to.have.length(5)
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
-                expect(spans[0]).to.have.property('name', 'express.request')
-                expect(spans[1]).to.have.property('resource', 'named')
-                expect(spans[1]).to.have.property('name', 'express.middleware')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
+                expect(spans[0].meta).to.have.property('component', 'express')
+                expect(spans[1]).to.have.property('name', 'named')
+                expect(spans[1].meta).to.have.property('component', 'express')
                 expect(spans[1].parent_id.toString()).to.equal(spans[0].trace_id.toString())
-                expect(spans[2]).to.have.property('resource', 'router')
-                expect(spans[2]).to.have.property('name', 'express.middleware')
-                expect(spans[3].resource).to.match(/^bound\s.*$/)
-                expect(spans[3]).to.have.property('name', 'express.middleware')
-                expect(spans[4]).to.have.property('resource', '<anonymous>')
-                expect(spans[4]).to.have.property('name', 'express.middleware')
+                expect(spans[2]).to.have.property('name', 'router')
+                expect(spans[2].meta).to.have.property('component', 'express')
+                expect(spans[3].name).to.match(/^bound\s.*$/)
+                expect(spans[3].meta).to.have.property('component', 'express')
+                expect(spans[4]).to.have.property('name', '<anonymous>')
+                expect(spans[4].meta).to.have.property('component', 'express')
               })
               .then(done)
               .catch(done)
@@ -194,7 +194,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app(/^\\/user\\/(\\d)$/)')
+                expect(spans[0]).to.have.property('name', 'GET /app(/^\\/user\\/(\\d)$/)')
               })
               .then(done)
               .catch(done)
@@ -222,7 +222,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -256,7 +256,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
+                expect(spans[0]).to.have.property('name', 'GET /foo/bar')
               })
               .then(done)
               .catch(done)
@@ -284,7 +284,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -313,7 +313,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -341,8 +341,11 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans.filter(span => span.name === 'express.request')).to.have.length(1)
-                expect(spans[0]).to.have.property('resource', 'GET /parent/child')
+                expect(spans.filter(span => {
+                  return span.meta.component === 'express' &&
+                         span.meta['http.url']
+                })).to.have.length(1)
+                expect(spans[0]).to.have.property('name', 'GET /parent/child')
               })
               .then(done)
               .catch(done)
@@ -385,7 +388,7 @@ describe('Plugin', () => {
         })
 
         it('should not lose the current path when changing scope', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
           const router = express.Router()
@@ -414,7 +417,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -428,7 +431,7 @@ describe('Plugin', () => {
         })
 
         it('should not lose the current path without a scope', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
           const router = express.Router()
@@ -452,7 +455,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -481,7 +484,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app')
+                expect(spans[0]).to.have.property('name', 'GET /app')
               })
               .then(done)
               .catch(done)
@@ -538,7 +541,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET')
+                expect(spans[0]).to.have.property('name', 'GET')
               })
               .then(done)
               .catch(done)
@@ -552,7 +555,7 @@ describe('Plugin', () => {
         })
 
         it('should activate a scope per middleware', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
 
@@ -589,7 +592,7 @@ describe('Plugin', () => {
         })
 
         it('should activate a span for every middleware on a route', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
 
@@ -645,7 +648,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
+                expect(spans[0]).to.have.property('name', 'GET /app/user/:id')
               })
               .then(done)
               .catch(done)
@@ -668,8 +671,8 @@ describe('Plugin', () => {
             agent.use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0].trace_id.toString()).to.equal('1234')
-              expect(spans[0].parent_id.toString()).to.equal('5678')
+              expect(spans[0].trace_id.toString()).to.equal('0000000000001234')
+              expect(spans[0].parent_id.toString()).to.equal('0000000000005678')
             })
               .then(done)
               .catch(done)
@@ -678,8 +681,8 @@ describe('Plugin', () => {
               axios
                 .get(`http://localhost:${port}/user`, {
                   headers: {
-                    'x-datadog-trace-id': '1234',
-                    'x-datadog-parent-id': '5678',
+                    'x-b3-traceid': '1234',
+                    'x-b3-spanid': '5678',
                     'ot-baggage-foo': 'bar'
                   }
                 })
@@ -703,8 +706,8 @@ describe('Plugin', () => {
             agent.use(traces => {
               const spans = sort(traces[0])
 
-              expect(spans[0]).to.have.property('error', 1)
-              expect(spans[0]).to.have.property('resource', 'GET /user')
+              expect(spans[0].meta).to.have.property('error', true)
+              expect(spans[0]).to.have.property('name', 'GET /user')
               expect(spans[0].meta).to.have.property('http.status_code', '500')
 
               done()
@@ -731,7 +734,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('error', 1)
+                expect(spans[0].meta).to.have.property('error', true)
                 expect(spans[0].meta).to.have.property('http.status_code', '500')
               })
               .then(done)
@@ -759,7 +762,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[1]).to.have.property('error', 1)
+                expect(spans[1].meta).to.have.property('error', true)
                 expect(spans[1].meta).to.have.property('error.type', error.name)
                 expect(spans[1].meta).to.have.property('error.msg', error.message)
                 expect(spans[1].meta).to.have.property('error.stack', error.stack)
@@ -781,7 +784,6 @@ describe('Plugin', () => {
       describe('with configuration', () => {
         before(() => {
           return agent.load(plugin, 'express', {
-            service: 'custom',
             validateStatus: code => code < 400,
             headers: ['User-Agent']
           })
@@ -807,7 +809,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('service', 'custom')
+                expect(spans[0]).to.have.property('service', 'test')
               })
               .then(done)
               .catch(done)
@@ -832,7 +834,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('error', 1)
+                expect(spans[0].meta).to.have.property('error', true)
               })
               .then(done)
               .catch(done)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -184,9 +184,9 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
-              expect(spans[0]).to.have.property('name', 'graphql.query')
-              expect(spans[0]).to.have.property('resource', 'query MyQuery')
+              expect(spans[0]).to.have.property('service', 'test')
+              // expect(spans[0]).to.have.property('name', 'graphql.query')
+              expect(spans[0]).to.have.property('name', 'query MyQuery')
               expect(spans[0].meta).to.have.property('graphql.document', source)
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'query')
               expect(spans[0].meta).to.have.property('graphql.operation.name', 'MyQuery')
@@ -219,9 +219,9 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[4]).to.have.property('service', 'test-graphql')
-              expect(spans[4]).to.have.property('name', 'graphql.field')
-              expect(spans[4]).to.have.property('resource', 'hello')
+              expect(spans[4]).to.have.property('service', 'test')
+              // expect(spans[4]).to.have.property('name', 'graphql.field')
+              expect(spans[4]).to.have.property('name', 'hello')
               expect(spans[4].meta).to.have.property('graphql.field.name', 'hello')
               expect(spans[4].meta).to.have.property('graphql.field.path', 'hello')
               expect(spans[4].meta).to.have.property('graphql.field.type', 'String')
@@ -241,9 +241,9 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[5]).to.have.property('service', 'test-graphql')
-              expect(spans[5]).to.have.property('name', 'graphql.resolve')
-              expect(spans[5]).to.have.property('resource', 'hello')
+              expect(spans[5]).to.have.property('service', 'test')
+              // expect(spans[5]).to.have.property('name', 'graphql.resolve')
+              expect(spans[5]).to.have.property('name', 'hello')
               expect(spans[5].meta).to.have.property('graphql.field.name', 'hello')
               expect(spans[5].meta).to.have.property('graphql.field.path', 'hello')
               expect(spans[5].meta).to.have.property('graphql.field.type', 'String')
@@ -264,8 +264,8 @@ describe('Plugin', () => {
 
               const query = spans[0]
               const parse = spans[1]
-              expect(parse).to.have.property('service', 'test-graphql')
-              expect(parse).to.have.property('name', 'graphql.parse')
+              expect(parse).to.have.property('service', 'test')
+              // expect(parse).to.have.property('name', 'graphql.parse')
               expect(parse.parent_id.toString()).to.equal(query.span_id.toString())
               expect(parse.start.toNumber()).to.be.gte(query.start.toNumber())
               expect(parse.duration.toNumber()).to.be.lte(query.duration.toNumber())
@@ -286,8 +286,8 @@ describe('Plugin', () => {
               const query = spans[0]
               const parse = spans[1]
               const validate = spans[2]
-              expect(validate).to.have.property('service', 'test-graphql')
-              expect(validate).to.have.property('name', 'graphql.validate')
+              expect(validate).to.have.property('service', 'test')
+              // expect(validate).to.have.property('name', 'graphql.validate')
 
               expect(validate.parent_id.toString()).to.equal(query.span_id.toString())
               expect(validate.start.toNumber()).to.be.gte(parse.start.toNumber() + parse.duration.toNumber())
@@ -309,8 +309,8 @@ describe('Plugin', () => {
               const query = spans[0]
               const validate = spans[2]
               const execute = spans[3]
-              expect(execute).to.have.property('service', 'test-graphql')
-              expect(execute).to.have.property('name', 'graphql.execute')
+              expect(execute).to.have.property('service', 'test')
+              // expect(execute).to.have.property('name', 'graphql.execute')
 
               expect(execute.parent_id.toString()).to.equal(query.span_id.toString())
               expect(execute.start.toNumber()).to.be.gte(validate.start.toNumber() + validate.duration.toNumber())
@@ -352,64 +352,64 @@ describe('Plugin', () => {
               const addressStreetField = spans[12]
               const addressStreetResolve = spans[13]
 
-              expect(execute).to.have.property('name', 'graphql.execute')
+              // expect(execute).to.have.property('name', 'graphql.execute')
 
-              expect(humanField).to.have.property('name', 'graphql.field')
-              expect(humanField).to.have.property('resource', 'human')
+              // expect(humanField).to.have.property('name', 'graphql.field')
+              expect(humanField).to.have.property('name', 'human')
               expect(humanField.meta).to.have.property('graphql.field.path', 'human')
               expect(humanField.parent_id.toString()).to.equal(execute.span_id.toString())
               expect(humanField.duration.toNumber()).to.be.lte(execute.duration.toNumber())
 
-              expect(humanResolve).to.have.property('name', 'graphql.resolve')
-              expect(humanResolve).to.have.property('resource', 'human')
+              // expect(humanResolve).to.have.property('name', 'graphql.resolve')
+              expect(humanResolve).to.have.property('name', 'human')
               expect(humanResolve.meta).to.have.property('graphql.field.path', 'human')
               expect(humanResolve.parent_id.toString()).to.equal(humanField.span_id.toString())
               expect(humanResolve.duration.toNumber()).to.be.lte(humanField.duration.toNumber())
 
-              expect(humanNameField).to.have.property('name', 'graphql.field')
-              expect(humanNameField).to.have.property('resource', 'human.name')
+              // expect(humanNameField).to.have.property('name', 'graphql.field')
+              expect(humanNameField).to.have.property('name', 'human.name')
               expect(humanNameField.meta).to.have.property('graphql.field.path', 'human.name')
               expect(humanNameField.parent_id.toString()).to.equal(humanField.span_id.toString())
 
-              expect(humanNameResolve).to.have.property('name', 'graphql.resolve')
-              expect(humanNameResolve).to.have.property('resource', 'human.name')
+              // expect(humanNameResolve).to.have.property('name', 'graphql.resolve')
+              expect(humanNameResolve).to.have.property('name', 'human.name')
               expect(humanNameResolve.meta).to.have.property('graphql.field.path', 'human.name')
               expect(humanNameResolve.parent_id.toString()).to.equal(humanNameField.span_id.toString())
 
-              expect(addressField).to.have.property('name', 'graphql.field')
-              expect(addressField).to.have.property('resource', 'human.address')
+              // expect(addressField).to.have.property('name', 'graphql.field')
+              expect(addressField).to.have.property('name', 'human.address')
               expect(addressField.meta).to.have.property('graphql.field.path', 'human.address')
               expect(addressField.parent_id.toString()).to.equal(humanField.span_id.toString())
               expect(addressField.duration.toNumber()).to.be.lte(humanField.duration.toNumber())
 
-              expect(addressResolve).to.have.property('name', 'graphql.resolve')
-              expect(addressResolve).to.have.property('resource', 'human.address')
+              // expect(addressResolve).to.have.property('name', 'graphql.resolve')
+              expect(addressResolve).to.have.property('name', 'human.address')
               expect(addressResolve.meta).to.have.property('graphql.field.path', 'human.address')
               expect(addressResolve.parent_id.toString()).to.equal(addressField.span_id.toString())
               expect(addressResolve.duration.toNumber()).to.be.lte(addressField.duration.toNumber())
 
-              expect(addressCivicNumberField).to.have.property('name', 'graphql.field')
-              expect(addressCivicNumberField).to.have.property('resource', 'human.address.civicNumber')
+              // expect(addressCivicNumberField).to.have.property('name', 'graphql.field')
+              expect(addressCivicNumberField).to.have.property('name', 'human.address.civicNumber')
               expect(addressCivicNumberField.meta).to.have.property('graphql.field.path', 'human.address.civicNumber')
               expect(addressCivicNumberField.parent_id.toString()).to.equal(addressField.span_id.toString())
               expect(addressCivicNumberField.duration.toNumber()).to.be.lte(addressField.duration.toNumber())
 
-              expect(addressCivicNumberResolve).to.have.property('name', 'graphql.resolve')
-              expect(addressCivicNumberResolve).to.have.property('resource', 'human.address.civicNumber')
+              // expect(addressCivicNumberResolve).to.have.property('name', 'graphql.resolve')
+              expect(addressCivicNumberResolve).to.have.property('name', 'human.address.civicNumber')
               expect(addressCivicNumberResolve.meta).to.have.property('graphql.field.path', 'human.address.civicNumber')
               expect(addressCivicNumberResolve.parent_id.toString())
                 .to.equal(addressCivicNumberField.span_id.toString())
               expect(addressCivicNumberResolve.duration.toNumber())
                 .to.be.lte(addressCivicNumberField.duration.toNumber())
 
-              expect(addressStreetField).to.have.property('name', 'graphql.field')
-              expect(addressStreetField).to.have.property('resource', 'human.address.street')
+              // expect(addressStreetField).to.have.property('name', 'graphql.field')
+              expect(addressStreetField).to.have.property('name', 'human.address.street')
               expect(addressStreetField.meta).to.have.property('graphql.field.path', 'human.address.street')
               expect(addressStreetField.parent_id.toString()).to.equal(addressField.span_id.toString())
               expect(addressStreetField.duration.toNumber()).to.be.lte(addressField.duration.toNumber())
 
-              expect(addressStreetResolve).to.have.property('name', 'graphql.resolve')
-              expect(addressStreetResolve).to.have.property('resource', 'human.address.street')
+              // expect(addressStreetResolve).to.have.property('name', 'graphql.resolve')
+              expect(addressStreetResolve).to.have.property('name', 'human.address.street')
               expect(addressStreetResolve.meta).to.have.property('graphql.field.path', 'human.address.street')
               expect(addressStreetResolve.parent_id.toString()).to.equal(addressStreetField.span_id.toString())
               expect(addressStreetResolve.duration.toNumber()).to.be.lte(addressStreetField.duration.toNumber())
@@ -446,45 +446,45 @@ describe('Plugin', () => {
               const petsNameField = spans[10]
               const petsNameResolve = spans[11]
 
-              expect(execute).to.have.property('name', 'graphql.execute')
+              // expect(execute).to.have.property('name', 'graphql.execute')
 
-              expect(friendsField).to.have.property('name', 'graphql.field')
-              expect(friendsField).to.have.property('resource', 'friends')
+              // expect(friendsField).to.have.property('name', 'graphql.field')
+              expect(friendsField).to.have.property('name', 'friends')
               expect(friendsField.meta).to.have.property('graphql.field.path', 'friends')
               expect(friendsField.parent_id.toString()).to.equal(execute.span_id.toString())
 
-              expect(friendsResolve).to.have.property('name', 'graphql.resolve')
-              expect(friendsResolve).to.have.property('resource', 'friends')
+              // expect(friendsResolve).to.have.property('name', 'graphql.resolve')
+              expect(friendsResolve).to.have.property('name', 'friends')
               expect(friendsResolve.meta).to.have.property('graphql.field.path', 'friends')
               expect(friendsResolve.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friendNameField).to.have.property('name', 'graphql.field')
-              expect(friendNameField).to.have.property('resource', 'friends.*.name')
+              // expect(friendNameField).to.have.property('name', 'graphql.field')
+              expect(friendNameField).to.have.property('name', 'friends.*.name')
               expect(friendNameField.meta).to.have.property('graphql.field.path', 'friends.*.name')
               expect(friendNameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friendNameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friendNameResolve).to.have.property('resource', 'friends.*.name')
+              // expect(friendNameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friendNameResolve).to.have.property('name', 'friends.*.name')
               expect(friendNameResolve.meta).to.have.property('graphql.field.path', 'friends.*.name')
               expect(friendNameResolve.parent_id.toString()).to.equal(friendNameField.span_id.toString())
 
-              expect(petsField).to.have.property('name', 'graphql.field')
-              expect(petsField).to.have.property('resource', 'friends.*.pets')
+              // expect(petsField).to.have.property('name', 'graphql.field')
+              expect(petsField).to.have.property('name', 'friends.*.pets')
               expect(petsField.meta).to.have.property('graphql.field.path', 'friends.*.pets')
               expect(petsField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(petsResolve).to.have.property('name', 'graphql.resolve')
-              expect(petsResolve).to.have.property('resource', 'friends.*.pets')
+              // expect(petsResolve).to.have.property('name', 'graphql.resolve')
+              expect(petsResolve).to.have.property('name', 'friends.*.pets')
               expect(petsResolve.meta).to.have.property('graphql.field.path', 'friends.*.pets')
               expect(petsResolve.parent_id.toString()).to.equal(petsField.span_id.toString())
 
-              expect(petsNameField).to.have.property('name', 'graphql.field')
-              expect(petsNameField).to.have.property('resource', 'friends.*.pets.*.name')
+              // expect(petsNameField).to.have.property('name', 'graphql.field')
+              expect(petsNameField).to.have.property('name', 'friends.*.pets.*.name')
               expect(petsNameField.meta).to.have.property('graphql.field.path', 'friends.*.pets.*.name')
               expect(petsNameField.parent_id.toString()).to.equal(petsField.span_id.toString())
 
-              expect(petsNameResolve).to.have.property('name', 'graphql.resolve')
-              expect(petsNameResolve).to.have.property('resource', 'friends.*.pets.*.name')
+              // expect(petsNameResolve).to.have.property('name', 'graphql.resolve')
+              expect(petsNameResolve).to.have.property('name', 'friends.*.pets.*.name')
               expect(petsNameResolve.meta).to.have.property('graphql.field.path', 'friends.*.pets.*.name')
               expect(petsNameResolve.parent_id.toString()).to.equal(petsNameField.span_id.toString())
             })
@@ -502,7 +502,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(8)
-              expect(spans[0]).to.have.property('name', 'graphql.mutation')
+              // expect(spans[0]).to.have.property('name', 'graphql.mutation')
             })
             .then(done)
             .catch(done)
@@ -518,7 +518,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[0]).to.have.property('name', 'graphql.subscription')
+              // expect(spans[0]).to.have.property('name', 'graphql.subscription')
             })
             .then(done)
             .catch(done)
@@ -551,7 +551,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(4)
-              expect(spans[0]).to.have.property('resource', 'query')
+              expect(spans[0]).to.have.property('name', 'query')
             })
             .then(done)
             .catch(done)
@@ -579,7 +579,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(4)
-              expect(spans[0]).to.have.property('resource', 'query')
+              expect(spans[0]).to.have.property('name', 'query')
             })
             .then(done)
             .catch(done)
@@ -607,7 +607,7 @@ describe('Plugin', () => {
         })
 
         it('should run rootValue resolvers in the current context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const schema = graphql.buildSchema(`
             type Query {
@@ -628,7 +628,7 @@ describe('Plugin', () => {
         })
 
         it('should run returned promise in the parent context', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const schema = graphql.buildSchema(`
             type Query {
@@ -673,12 +673,12 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[0]).to.have.property('name', 'graphql.query')
-              expect(spans[1]).to.have.property('name', 'graphql.parse')
-              expect(spans[2]).to.have.property('name', 'graphql.validate')
-              expect(spans[3]).to.have.property('name', 'graphql.execute')
-              expect(spans[4]).to.have.property('name', 'graphql.field')
-              expect(spans[5]).to.have.property('name', 'graphql.resolve')
+              // expect(spans[0]).to.have.property('name', 'graphql.query')
+              // expect(spans[1]).to.have.property('name', 'graphql.parse')
+              // expect(spans[2]).to.have.property('name', 'graphql.validate')
+              // expect(spans[3]).to.have.property('name', 'graphql.execute')
+              // expect(spans[4]).to.have.property('name', 'graphql.field')
+              // expect(spans[5]).to.have.property('name', 'graphql.resolve')
             })
             .then(done)
             .catch(done)
@@ -698,9 +698,9 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(5)
-              expect(spans[0]).to.have.property('service', 'test-graphql')
-              expect(spans[0]).to.have.property('name', 'graphql.query')
-              expect(spans[0]).to.have.property('resource', 'query MyQuery')
+              expect(spans[0]).to.have.property('service', 'test')
+              // expect(spans[0]).to.have.property('name', 'graphql.query')
+              expect(spans[0]).to.have.property('name', 'query MyQuery')
               expect(spans[0].meta).to.have.property('graphql.document', source)
             })
             .then(done)
@@ -720,9 +720,9 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(3)
-              expect(spans[2]).to.have.property('service', 'test-graphql')
-              expect(spans[2]).to.have.property('name', 'graphql.execute')
-              expect(spans[2]).to.have.property('error', 1)
+              expect(spans[2]).to.have.property('service', 'test')
+              // expect(spans[2]).to.have.property('name', 'graphql.execute')
+              expect(spans[2].meta).to.have.property('error', true)
               expect(spans[2].meta).to.have.property('error.type', error.name)
               expect(spans[2].meta).to.have.property('error.msg', error.message)
               expect(spans[2].meta).to.have.property('error.stack', error.stack)
@@ -759,7 +759,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[5]).to.have.property('error', 1)
+              expect(spans[5].meta).to.have.property('error', true)
               expect(spans[5].meta).to.have.property('error.type', error.name)
               expect(spans[5].meta).to.have.property('error.msg', error.message)
               expect(spans[5].meta).to.have.property('error.stack', error.stack)
@@ -792,7 +792,7 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(6)
-              expect(spans[5]).to.have.property('error', 1)
+              expect(spans[5].meta).to.have.property('error', true)
               expect(spans[5].meta).to.have.property('error.type', error.name)
               expect(spans[5].meta).to.have.property('error.msg', error.message)
               expect(spans[5].meta).to.have.property('error.stack', error.stack)
@@ -958,10 +958,10 @@ describe('Plugin', () => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(4)
-              expect(spans[0]).to.have.property('name', 'graphql.query')
-              expect(spans[1]).to.have.property('name', 'graphql.parse')
-              expect(spans[2]).to.have.property('name', 'graphql.validate')
-              expect(spans[3]).to.have.property('name', 'graphql.execute')
+              // expect(spans[0]).to.have.property('name', 'graphql.query')
+              // expect(spans[1]).to.have.property('name', 'graphql.parse')
+              // expect(spans[2]).to.have.property('name', 'graphql.validate')
+              // expect(spans[3]).to.have.property('name', 'graphql.execute')
             })
             .then(done)
             .catch(done)
@@ -970,7 +970,7 @@ describe('Plugin', () => {
         })
 
         it('should run the resolvers in the execution scope', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const schema = graphql.buildSchema(`
             type Query {
@@ -1084,30 +1084,30 @@ describe('Plugin', () => {
               const friend1NameField = spans[8]
               const friend1NameResolve = spans[9]
 
-              expect(execute).to.have.property('name', 'graphql.execute')
+              // expect(execute).to.have.property('name', 'graphql.execute')
 
-              expect(friendsField).to.have.property('name', 'graphql.field')
-              expect(friendsField).to.have.property('resource', 'friends')
+              // expect(friendsField).to.have.property('name', 'graphql.field')
+              expect(friendsField).to.have.property('name', 'friends')
               expect(friendsField.parent_id.toString()).to.equal(execute.span_id.toString())
 
-              expect(friendsResolve).to.have.property('name', 'graphql.resolve')
-              expect(friendsResolve).to.have.property('resource', 'friends')
+              // expect(friendsResolve).to.have.property('name', 'graphql.resolve')
+              expect(friendsResolve).to.have.property('name', 'friends')
               expect(friendsResolve.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friend0NameField).to.have.property('name', 'graphql.field')
-              expect(friend0NameField).to.have.property('resource', 'friends.0.name')
+              // expect(friend0NameField).to.have.property('name', 'graphql.field')
+              expect(friend0NameField).to.have.property('name', 'friends.0.name')
               expect(friend0NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friend0NameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friend0NameResolve).to.have.property('resource', 'friends.0.name')
+              // expect(friend0NameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friend0NameResolve).to.have.property('name', 'friends.0.name')
               expect(friend0NameResolve.parent_id.toString()).to.equal(friend0NameField.span_id.toString())
 
-              expect(friend1NameField).to.have.property('name', 'graphql.field')
-              expect(friend1NameField).to.have.property('resource', 'friends.1.name')
+              // expect(friend1NameField).to.have.property('name', 'graphql.field')
+              expect(friend1NameField).to.have.property('name', 'friends.1.name')
               expect(friend1NameField.parent_id.toString()).to.equal(friendsField.span_id.toString())
 
-              expect(friend1NameResolve).to.have.property('name', 'graphql.resolve')
-              expect(friend1NameResolve).to.have.property('resource', 'friends.1.name')
+              // expect(friend1NameResolve).to.have.property('name', 'graphql.resolve')
+              expect(friend1NameResolve).to.have.property('name', 'friends.1.name')
               expect(friend1NameResolve.parent_id.toString()).to.equal(friend1NameField.span_id.toString())
             })
             .then(done)
@@ -1149,35 +1149,35 @@ describe('Plugin', () => {
 
               expect(spans).to.have.length(11)
 
-              expect(spans[0]).to.have.property('name', 'graphql.query')
-              expect(spans[0]).to.have.property('resource', 'query MyQuery')
+              // expect(spans[0]).to.have.property('name', 'graphql.query')
+              expect(spans[0]).to.have.property('name', 'query MyQuery')
               expect(spans[0].meta).to.have.property('graphql.document')
 
-              expect(spans[1]).to.have.property('name', 'graphql.parse')
+              // expect(spans[1]).to.have.property('name', 'graphql.parse')
 
-              expect(spans[2]).to.have.property('name', 'graphql.validate')
+              // expect(spans[2]).to.have.property('name', 'graphql.validate')
 
-              expect(spans[3]).to.have.property('name', 'graphql.execute')
+              // expect(spans[3]).to.have.property('name', 'graphql.execute')
 
-              expect(spans[4]).to.have.property('name', 'graphql.field')
-              expect(spans[4]).to.have.property('resource', 'hello')
+              // expect(spans[4]).to.have.property('name', 'graphql.field')
+              expect(spans[4]).to.have.property('name', 'hello')
 
-              expect(spans[5]).to.have.property('name', 'graphql.resolve')
-              expect(spans[5]).to.have.property('resource', 'hello')
+              // expect(spans[5]).to.have.property('name', 'graphql.resolve')
+              expect(spans[5]).to.have.property('name', 'hello')
 
-              expect(spans[6]).to.have.property('name', 'graphql.query')
-              expect(spans[6]).to.have.property('resource', 'query MyQuery')
+              // expect(spans[6]).to.have.property('name', 'graphql.query')
+              expect(spans[6]).to.have.property('name', 'query MyQuery')
               expect(spans[6].meta).to.not.have.property('graphql.document')
 
-              expect(spans[7]).to.have.property('name', 'graphql.validate')
+              // expect(spans[7]).to.have.property('name', 'graphql.validate')
 
-              expect(spans[8]).to.have.property('name', 'graphql.execute')
+              // expect(spans[8]).to.have.property('name', 'graphql.execute')
 
-              expect(spans[9]).to.have.property('name', 'graphql.field')
-              expect(spans[9]).to.have.property('resource', 'hello')
+              // expect(spans[9]).to.have.property('name', 'graphql.field')
+              expect(spans[9]).to.have.property('name', 'hello')
 
-              expect(spans[10]).to.have.property('name', 'graphql.resolve')
-              expect(spans[10]).to.have.property('resource', 'hello')
+              // expect(spans[10]).to.have.property('name', 'graphql.resolve')
+              expect(spans[10]).to.have.property('name', 'hello')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/hapi.spec.js
+++ b/test/plugins/hapi.spec.js
@@ -84,10 +84,9 @@ describe('Plugin', () => {
 
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'hapi.request')
             expect(traces[0][0]).to.have.property('service', 'test')
-            expect(traces[0][0]).to.have.property('type', 'http')
-            expect(traces[0][0]).to.have.property('resource', 'GET /user/{id}')
+            expect(traces[0][0]).to.have.property('name', 'GET /user/{id}')
+            expect(traces[0][0].meta).to.have.property('component', 'hapi')
             expect(traces[0][0].meta).to.have.property('span.kind', 'server')
             expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
             expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -172,8 +171,8 @@ describe('Plugin', () => {
 
         agent
           .use(traces => {
-            expect(traces[0][0].trace_id.toString()).to.equal('1234')
-            expect(traces[0][0].parent_id.toString()).to.equal('5678')
+            expect(traces[0][0].trace_id.toString()).to.equal('0000000000001234')
+            expect(traces[0][0].parent_id.toString()).to.equal('0000000000005678')
           })
           .then(done)
           .catch(done)
@@ -181,8 +180,8 @@ describe('Plugin', () => {
         axios
           .get(`http://localhost:${port}/user/123`, {
             headers: {
-              'x-datadog-trace-id': '1234',
-              'x-datadog-parent-id': '5678',
+              'x-b3-traceid': '1234',
+              'x-b3-spanid': '5678',
               'ot-baggage-foo': 'bar'
             }
           })
@@ -192,7 +191,7 @@ describe('Plugin', () => {
       it('should instrument the default route handler', done => {
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'hapi.request')
+            expect(traces[0][0].meta).to.have.property('component', 'hapi')
           })
           .then(done)
           .catch(done)
@@ -219,7 +218,7 @@ describe('Plugin', () => {
 
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('error', 1)
+            expect(traces[0][0].meta).to.have.property('error', true)
           })
           .then(done)
           .catch(done)

--- a/test/plugins/http/client.spec.js
+++ b/test/plugins/http/client.spec.js
@@ -63,9 +63,9 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('service', 'test-http-client')
-                expect(traces[0][0]).to.have.property('type', 'web')
-                expect(traces[0][0]).to.have.property('resource', 'GET')
+                expect(traces[0][0]).to.have.property('service', 'test')
+                expect(traces[0][0]).to.have.property('name', 'GET')
+                expect(traces[0][0].meta).to.have.property('component', 'http')
                 expect(traces[0][0].meta).to.have.property('span.kind', 'client')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
                 expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -267,8 +267,8 @@ describe('Plugin', () => {
           const app = express()
 
           app.get('/user', (req, res) => {
-            expect(req.get('x-datadog-trace-id')).to.be.a('string')
-            expect(req.get('x-datadog-parent-id')).to.be.a('string')
+            expect(req.get('x-b3-traceid')).to.be.a('string')
+            expect(req.get('x-b3-spanid')).to.be.a('string')
 
             res.status(200).send()
           })
@@ -294,8 +294,8 @@ describe('Plugin', () => {
 
           app.get('/', (req, res) => {
             try {
-              expect(req.get('x-datadog-trace-id')).to.be.undefined
-              expect(req.get('x-datadog-parent-id')).to.be.undefined
+              expect(req.get('x-b3-traceid')).to.be.undefined
+              expect(req.get('x-b3-spanid')).to.be.undefined
 
               res.status(200).send()
 
@@ -408,7 +408,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
 
@@ -429,7 +429,7 @@ describe('Plugin', () => {
         })
 
         it('should run the event listeners in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = express()
 
@@ -456,6 +456,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
+                expect(traces[0][0].meta).to.have.property('error', true)
                 expect(traces[0][0].meta).to.have.property('error.type', 'Error')
                 expect(traces[0][0].meta).to.have.property('error.msg', `connect ECONNREFUSED 127.0.0.1:${port}`)
                 expect(traces[0][0].meta).to.have.property('error.stack')
@@ -479,7 +480,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 0)
+                expect(traces[0][0].meta).to.not.have.property('error')
               })
               .then(done)
               .catch(done)
@@ -504,7 +505,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.have.property('error', true)
               })
               .then(done)
               .catch(done)
@@ -587,7 +588,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('service', 'custom')
+                expect(traces[0][0]).to.have.property('service', 'test')
               })
               .then(done)
               .catch(done)
@@ -628,7 +629,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('error', 1)
+                expect(traces[0][0].meta).to.have.property('error', true)
               })
               .then(done)
               .catch(done)
@@ -669,7 +670,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
+                expect(traces[0][0]).to.have.property('service', 'test')
               })
               .then(done)
               .catch(done)

--- a/test/plugins/http/server.spec.js
+++ b/test/plugins/http/server.spec.js
@@ -54,10 +54,9 @@ describe('Plugin', () => {
       it('should do automatic instrumentation', done => {
         agent
           .use(traces => {
-            expect(traces[0][0]).to.have.property('name', 'http.request')
+            expect(traces[0][0]).to.have.property('name', 'GET')
             expect(traces[0][0]).to.have.property('service', 'test')
-            expect(traces[0][0]).to.have.property('type', 'http')
-            expect(traces[0][0]).to.have.property('resource', 'GET')
+            expect(traces[0][0].meta).to.have.property('component', 'http')
             expect(traces[0][0].meta).to.have.property('span.kind', 'server')
             expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
             expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -70,7 +69,7 @@ describe('Plugin', () => {
       })
 
       it('should run the request listener in the request scope', done => {
-        if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+        if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
         app = (req, res) => {
           expect(tracer.scopeManager().active()).to.not.be.null

--- a/test/plugins/ioredis.spec.js
+++ b/test/plugins/ioredis.spec.js
@@ -30,10 +30,9 @@ describe('Plugin', () => {
           agent.use(() => {}) // wait for initial info command
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'redis.command')
-              expect(traces[0][0]).to.have.property('service', 'test-redis')
-              expect(traces[0][0]).to.have.property('resource', 'get')
-              expect(traces[0][0]).to.have.property('type', 'redis')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'get')
+              expect(traces[0][0].meta).to.have.property('component', 'redis')
               expect(traces[0][0].meta).to.have.property('db.name', '0')
               expect(traces[0][0].meta).to.have.property('db.type', 'redis')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
@@ -48,7 +47,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
 
@@ -69,7 +68,7 @@ describe('Plugin', () => {
           agent.use(() => {}) // wait for initial info command
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.have.property('error', true)
               expect(traces[0][0].meta).to.have.property('error.type', error.name)
               expect(traces[0][0].meta).to.have.property('error.msg', error.message)
               expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
@@ -91,7 +90,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'test')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/koa.spec.js
+++ b/test/plugins/koa.spec.js
@@ -41,10 +41,9 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'koa.request')
               expect(traces[0][0]).to.have.property('service', 'test')
-              expect(traces[0][0]).to.have.property('type', 'http')
-              expect(traces[0][0]).to.have.property('resource', 'GET')
+              expect(traces[0][0]).to.have.property('name', 'GET')
+              expect(traces[0][0].meta).to.have.property('component', 'koa')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
               expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -70,10 +69,9 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'koa.request')
               expect(traces[0][0]).to.have.property('service', 'test')
-              expect(traces[0][0]).to.have.property('type', 'http')
-              expect(traces[0][0]).to.have.property('resource', 'GET')
+              expect(traces[0][0]).to.have.property('name', 'GET')
+              expect(traces[0][0].meta).to.have.property('component', 'koa')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
               expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -90,7 +88,7 @@ describe('Plugin', () => {
         })
 
         it('should run middleware in the request scope', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = new Koa()
 
@@ -115,7 +113,7 @@ describe('Plugin', () => {
         })
 
         it('should reactivate the request span in middleware scopes', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const app = new Koa()
 
@@ -170,7 +168,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0]).to.have.property('name', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
               })
               .then(done)
@@ -198,7 +196,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0]).to.have.property('name', 'GET /user/:id')
               })
               .then(done)
               .catch(done)
@@ -225,7 +223,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /forums/:fid/posts/:pid')
+                expect(traces[0][0]).to.have.property('name', 'GET /forums/:fid/posts/:pid')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/forums/123/posts/456`)
               })
               .then(done)
@@ -256,7 +254,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /forums/:fid/posts/:pid')
+                expect(traces[0][0]).to.have.property('name', 'GET /forums/:fid/posts/:pid')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/forums/123/posts/456`)
               })
               .then(done)
@@ -285,7 +283,7 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0]).to.have.property('name', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
               })
               .then(done)
@@ -315,9 +313,9 @@ describe('Plugin', () => {
 
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0]).to.have.property('name', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
-                expect(traces[0][0].error).to.equal(1)
+                expect(traces[0][0].meta.error).to.equal(true)
               })
               .then(done)
               .catch(done)

--- a/test/plugins/memcached.spec.js
+++ b/test/plugins/memcached.spec.js
@@ -30,10 +30,9 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'memcached.command')
-              expect(traces[0][0]).to.have.property('service', 'test-memcached')
-              expect(traces[0][0]).to.have.property('resource', 'get')
-              expect(traces[0][0]).to.have.property('type', 'memcached')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'get')
+              expect(traces[0][0].meta).to.have.property('component', 'memcached')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
               expect(traces[0][0].meta).to.have.property('out.port', '11211')
@@ -46,7 +45,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           memcached = new Memcached('localhost:11211', { retries: 0 })
 
@@ -65,7 +64,7 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.have.property('error', true)
               expect(traces[0][0].meta).to.have.property('error.type', error.name)
               expect(traces[0][0].meta).to.have.property('error.msg', error.message)
               expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
@@ -146,7 +145,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'test')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/mongodb-core.spec.js
+++ b/test/plugins/mongodb-core.spec.js
@@ -58,10 +58,9 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `insert test.${collection}`
 
-                expect(span).to.have.property('name', 'mongodb.query')
-                expect(span).to.have.property('service', 'test-mongodb')
-                expect(span).to.have.property('resource', resource)
-                expect(span).to.have.property('type', 'mongodb')
+                expect(span).to.have.property('service', 'test')
+                expect(span).to.have.property('name', resource)
+                expect(span.meta).to.have.property('component', 'mongodb')
                 expect(span.meta).to.have.property('db.name', `test.${collection}`)
                 expect(span.meta).to.have.property('out.host', 'localhost')
               })
@@ -77,7 +76,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `planCacheListPlans test.${collection} {}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
               })
               .then(done)
               .catch(done)
@@ -95,7 +94,7 @@ describe('Plugin', () => {
                 const query = '{"foo":"?","bar":{"baz":"?"}}'
                 const resource = `find test.${collection} ${query}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
                 expect(span.meta).to.have.property('mongodb.query', query)
               })
               .then(done)
@@ -118,7 +117,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `find test.${collection} {"_id":"?"}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
               })
               .then(done)
               .catch(done)
@@ -139,7 +138,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `find test.${collection} {"_id":"?"}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
               })
               .then(done)
               .catch(done)
@@ -158,7 +157,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `find test.${collection} {"_id":"?"}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
               })
               .then(done)
               .catch(done)
@@ -173,7 +172,7 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             server.insert(`test.${collection}`, [{ a: 1 }], {}, () => {
               expect(tracer.scopeManager().active()).to.be.null
@@ -206,9 +205,9 @@ describe('Plugin', () => {
               .use(traces => {
                 const span = traces[0][0]
 
-                expect(span).to.have.property('name', 'mongodb.query')
-                expect(span).to.have.property('service', 'test-mongodb')
-                expect(span).to.have.property('type', 'mongodb')
+                expect(span).to.have.property('name', `insert test.${collection}`)
+                expect(span).to.have.property('service', 'test')
+                expect(span.meta).to.have.property('component', 'mongodb')
                 expect(span.meta).to.have.property('db.name', `test.${collection}`)
                 expect(span.meta).to.have.property('out.host', 'localhost')
                 expect(span.meta).to.have.property('out.port', '27017')
@@ -259,7 +258,7 @@ describe('Plugin', () => {
                 const span = traces[0][0]
                 const resource = `find test.${collection} {"foo":"?","bar":{"baz":"?"}}`
 
-                expect(span).to.have.property('resource', resource)
+                expect(span).to.have.property('name', resource)
               })
               .then(done)
               .catch(done)
@@ -278,7 +277,7 @@ describe('Plugin', () => {
           })
 
           it('should run the callback in the parent context', done => {
-            if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+            if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
             const cursor = server.cursor(`test.${collection}`, {
               find: `test.${collection}`,
@@ -391,7 +390,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'test')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -43,7 +43,7 @@ describe('Plugin', () => {
         })
 
         it('should propagate context to callbacks', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const span = tracer.startSpan('test')
           const scope = tracer.scopeManager().activate(span)
@@ -56,7 +56,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           connection.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
@@ -66,7 +66,7 @@ describe('Plugin', () => {
         })
 
         it('should run event listeners in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const query = connection.query('SELECT 1 + 1 AS solution')
 
@@ -79,9 +79,9 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'test-mysql')
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'sql')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('name', 'SELECT 1 + 1 AS solution')
+            expect(traces[0][0].meta).to.have.property('component', 'mysql')
             expect(traces[0][0].meta).to.have.property('db.name', 'db')
             expect(traces[0][0].meta).to.have.property('db.user', 'root')
             expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
@@ -99,6 +99,7 @@ describe('Plugin', () => {
           let error
 
           agent.use(traces => {
+            expect(traces[0][0].meta).to.have.property('error', true)
             expect(traces[0][0].meta).to.have.property('error.type', error.name)
             expect(traces[0][0].meta).to.have.property('error.msg', error.message)
             expect(traces[0][0].meta).to.have.property('error.stack', error.stack)
@@ -149,7 +150,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'custom')
+            expect(traces[0][0]).to.have.property('service', 'test')
             done()
           })
 
@@ -185,9 +186,9 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'test-mysql')
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'sql')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('name', 'SELECT 1 + 1 AS solution')
+            expect(traces[0][0].meta).to.have.property('component', 'mysql')
             expect(traces[0][0].meta).to.have.property('db.user', 'root')
             expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
             expect(traces[0][0].meta).to.have.property('span.kind', 'client')
@@ -199,7 +200,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           pool.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()

--- a/test/plugins/mysql2.spec.js
+++ b/test/plugins/mysql2.spec.js
@@ -43,7 +43,7 @@ describe('Plugin', () => {
         })
 
         it('should propagate context to callbacks', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const span = tracer.startSpan('test')
           const scope = tracer.scopeManager().activate(span)
@@ -56,7 +56,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           connection.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()
@@ -66,7 +66,7 @@ describe('Plugin', () => {
         })
 
         it('should run event listeners in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const query = connection.query('SELECT 1 + 1 AS solution')
 
@@ -80,9 +80,9 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'test-mysql')
-              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'SELECT 1 + 1 AS solution')
+              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
               expect(traces[0][0].meta).to.have.property('db.name', 'db')
               expect(traces[0][0].meta).to.have.property('db.user', 'root')
               expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
@@ -153,7 +153,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'test')
             })
             .then(done)
             .catch(done)
@@ -190,9 +190,9 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'test-mysql')
-              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'SELECT 1 + 1 AS solution')
+              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
               expect(traces[0][0].meta).to.have.property('db.user', 'root')
               expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
@@ -204,7 +204,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           pool.query('SELECT 1 + 1 AS solution', () => {
             const active = tracer.scopeManager().active()

--- a/test/plugins/pg.spec.js
+++ b/test/plugins/pg.spec.js
@@ -41,9 +41,9 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation when using callbacks', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'test-postgres')
-            expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
-            expect(traces[0][0]).to.have.property('type', 'sql')
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('name', 'SELECT $1::text as message')
+            expect(traces[0][0].meta).to.have.property('component', 'pg')
             expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
             expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
             expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
@@ -64,9 +64,9 @@ describe('Plugin', () => {
         if (semver.intersects(version, '>=5.1')) { // initial promise support
           it('should do automatic instrumentation when using promises', done => {
             agent.use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'test-postgres')
-              expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
-              expect(traces[0][0]).to.have.property('type', 'sql')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'SELECT $1::text as message')
+              expect(traces[0][0].meta).to.have.property('component', 'pg')
               expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.user', 'postgres')
               expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
@@ -100,7 +100,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const span = {}
           const scope = tracer.scopeManager().activate(span)
@@ -140,7 +140,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'custom')
+            expect(traces[0][0]).to.have.property('service', 'test')
 
             done()
           })

--- a/test/plugins/q.spec.js
+++ b/test/plugins/q.spec.js
@@ -28,7 +28,7 @@ describe('Plugin', () => {
         })
 
         it('should run the then() callback in context where then() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const deferred = Q.defer()
@@ -54,7 +54,7 @@ describe('Plugin', () => {
         })
 
         it('should run the catch() callback in context where catch() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const deferred = Q.defer()

--- a/test/plugins/redis.spec.js
+++ b/test/plugins/redis.spec.js
@@ -45,10 +45,9 @@ describe('Plugin', () => {
 
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'redis.command')
-              expect(traces[0][0]).to.have.property('service', 'test-redis')
-              expect(traces[0][0]).to.have.property('resource', 'get')
-              expect(traces[0][0]).to.have.property('type', 'redis')
+              expect(traces[0][0]).to.have.property('service', 'test')
+              expect(traces[0][0]).to.have.property('name', 'get')
+              expect(traces[0][0].meta).to.have.property('component', 'redis')
               expect(traces[0][0].meta).to.have.property('db.name', '0')
               expect(traces[0][0].meta).to.have.property('db.type', 'redis')
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
@@ -74,7 +73,7 @@ describe('Plugin', () => {
         })
 
         it('should run the callback in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           client.on('error', done)
 
@@ -85,7 +84,7 @@ describe('Plugin', () => {
         })
 
         it('should run client emitter listeners in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           client.on('error', done)
 
@@ -96,7 +95,7 @@ describe('Plugin', () => {
         })
 
         it('should run stream emitter listeners in the parent context', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           client.on('error', done)
 
@@ -147,7 +146,7 @@ describe('Plugin', () => {
         it('should be configured with the correct values', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+              expect(traces[0][0]).to.have.property('service', 'test')
             })
             .then(done)
             .catch(done)

--- a/test/plugins/restify.spec.js
+++ b/test/plugins/restify.spec.js
@@ -37,10 +37,9 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('name', 'restify.request')
                 expect(traces[0][0]).to.have.property('service', 'test')
-                expect(traces[0][0]).to.have.property('type', 'http')
-                expect(traces[0][0]).to.have.property('resource', 'GET')
+                expect(traces[0][0]).to.have.property('name', 'GET')
+                expect(traces[0][0].meta).to.have.property('component', 'restify')
                 expect(traces[0][0].meta).to.have.property('span.kind', 'server')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
                 expect(traces[0][0].meta).to.have.property('http.method', 'GET')
@@ -68,7 +67,7 @@ describe('Plugin', () => {
           getPort().then(port => {
             agent
               .use(traces => {
-                expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
+                expect(traces[0][0]).to.have.property('name', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
               })
               .then(done)
@@ -83,7 +82,7 @@ describe('Plugin', () => {
         })
 
         it('should run handlers in the request scope', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const server = restify.createServer()
 
@@ -114,7 +113,7 @@ describe('Plugin', () => {
         })
 
         it('should reactivate the request span in middleware scopes', done => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return done()
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
 
           const server = restify.createServer()
 

--- a/test/plugins/router.spec.js
+++ b/test/plugins/router.spec.js
@@ -70,7 +70,7 @@ describe('Plugin', () => {
               .use(traces => {
                 const spans = sort(traces[0])
 
-                expect(spans[0]).to.have.property('resource', 'GET /parent/child/:id')
+                expect(spans[0]).to.have.property('name', 'GET /parent/child/:id')
               })
               .then(done)
               .catch(done)

--- a/test/plugins/util/redis.spec.js
+++ b/test/plugins/util/redis.spec.js
@@ -30,7 +30,7 @@ describe('plugins/util/redis', () => {
     })
 
     it('should use the parent from the scope', () => {
-      if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+      if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
       const parent = tracer.startSpan('parent')
 

--- a/test/plugins/when.spec.js
+++ b/test/plugins/when.spec.js
@@ -28,7 +28,7 @@ describe('Plugin', () => {
         })
 
         it('should run the then() callback in context where then() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const deferred = when.defer()
@@ -54,7 +54,7 @@ describe('Plugin', () => {
         })
 
         it('should run the catch() callback in context where catch() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const deferred = when.defer()
@@ -81,7 +81,7 @@ describe('Plugin', () => {
         })
 
         it('should run the onProgress callback in context where then() was called', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
           const deferred = when.defer()


### PR DESCRIPTION
These changes rename the configuration environment variables and update expected test values for Zipkin span format (by way of translator helper).

Also adopts component tags both directly in instrumentations and by way of `span.type` where not explicitly set.