### PR TITLE
Expose updated TracerOptions

### DIFF
--- a/docs/index.d.ts
+++ b/docs/index.d.ts
@@ -108,9 +108,24 @@ export declare interface TracerOptions {
 
   /**
    * The service name to be used for this program. If not set, the service name
-   * will attempted to be inferred from package.json
+   * will attempted to be inferred from SIGNALFX_SERVICE_NAME environment variable
+   * or package.json
    */
   service?: string;
+
+  /**
+   * The optional SignalFx Organization Access Token.  Unnecessary if configured on
+   * Smart Agent and Gateway directly.  Also configurable via SIGNALFX_ACCESS_TOKEN
+   */
+  accessToken?: string;
+
+  /**
+   * The endpoint url for sending traces (Smart Agent or Gateway). Used over
+   * hostname and port if set.  Also configurable via SIGNALFX_ENDPOINT_URL
+   * environment variable
+   * @default 'http://localhost:9080/v1/trace'
+   */
+  url?: string;
 
   /**
    * The address of the trace agent that the tracer will submit to.
@@ -120,7 +135,7 @@ export declare interface TracerOptions {
 
   /**
    * The port of the trace agent that the tracer will submit to.
-   * @default 8126
+   * @default 9080
    */
   port?: number | string;
 

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -1,4 +1,4 @@
-import ddTrace, { tracer, Tracer, TracerOptions, Span, SpanContext, SpanOptions, Scope } from '..';
+import sfxTrace, { tracer, Tracer, TracerOptions, Span, SpanContext, SpanOptions, Scope } from '..';
 import { HTTP_HEADERS } from '../ext/formats';
 import * as opentracing from 'opentracing';
 
@@ -9,7 +9,7 @@ let context: SpanContext;
 let traceId: string;
 let spanId: string;
 
-ddTrace.init();
+sfxTrace.init();
 tracer.init({
   debug: true,
   enabled: true,
@@ -26,7 +26,9 @@ tracer.init({
   service: 'test',
   tags: {
     foo: 'bar'
-  }
+  },
+  url: 'http://localhost:9080/v1/trace',
+  accessToken: 'MyAccessToken'
 });
 
 const httpOptions = {

--- a/docs/typedoc.js
+++ b/docs/typedoc.js
@@ -6,7 +6,7 @@ module.exports = {
   excludeProtected: true,
   includeDeclarations: true,
   mode: 'file',
-  name: 'dd-trace',
+  name: 'signalfx-tracing',
   out: 'out',
   readme: 'API.md'
 }


### PR DESCRIPTION
Overriding defaults is not currently possible in Typescript environments.  These changes expose the new properties.