### PR TITLE
Allow Express route parameters in operation names

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -21,6 +21,7 @@ require,require-in-the-middle,MIT,Copyright 2016-2018 Thomas Watson Steen
 require,safe-buffer,MIT,Copyright Feross Aboukhadijeh
 require,shimmer,BSD-2-Clause,Copyright Forrest L Norvell
 require,url-parse,MIT,Copyright 2015 Unshift.io Arnout Kazemier the Contributors
+require,xregexp,MIT,Copyright 2007-present Steven Levithan
 dev,axios,MIT,Copyright 2014-present Matt Zabriskie
 dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David Dalton
 dev,body-parser,MIT,Copyright 2014 Jonathan Ong 2014-2015 Douglas Christopher Wilson

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,10 +267,11 @@ Each integration also has its own list of default tags. These tags get automatic
 
 ##### Configuration Options
 
-| Option           | Default                   | Description                            |
-|------------------|---------------------------|----------------------------------------|
-| validateStatus   | `code => code < 500`      | Callback function to determine if there was an error. It should take a status code as its only parameter and return `true` for success or `false` for errors. |
-| headers          | `[]`                      | An array of headers to include in the span tags. |
+| Option                    | Default                   | Description                            |
+|-------------------------|---------------------------|----------------------------------------|
+| validateStatus          | `code => code < 500`      | Callback function to determine if there was an error. It should take a status code as its only parameter and return `true` for success or `false` for errors. |
+| headers                 | `[]`                      | An array of headers to include in the span tags. |
+| expandRouteParameters | `{}`                      | An object of the form `{ '/exact/path/:paramOne/:paramTwo': { 'paramOne': true } }` that will expand parameter values for operation names for each request to that path.  Be sure to only use for low-cardinality parameters.  Omitted parameters default to `false`. |
 
 #### graphql
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "safe-buffer": "^5.1.1",
     "semver": "^5.5.0",
     "shimmer": "^1.2.0",
-    "url-parse": "^1.4.3"
+    "url-parse": "^1.4.3",
+    "xregexp": "^4.2.4"
   },
   "devDependencies": {
     "axios": "^0.18.0",

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -70,6 +70,7 @@ describe('plugins/util/web', () => {
       expect(config.hooks).to.be.an('object')
       expect(config.hooks).to.have.property('request')
       expect(config.hooks.request).to.be.a('function')
+      expect(config.expandRouteParameters).to.be.an('object')
     })
 
     it('should use the shared config if set', () => {
@@ -78,13 +79,15 @@ describe('plugins/util/web', () => {
         validateStatus: code => false,
         hooks: {
           request: () => 'test'
-        }
+        },
+        expandRouteParameters: { '/path': { 'thing': true } }
       })
 
       expect(config.headers).to.include('test')
       expect(config.validateStatus(200)).to.equal(false)
       expect(config).to.have.property('hooks')
       expect(config.hooks.request()).to.equal('test')
+      expect(config.expandRouteParameters).to.deep.equal({ '/path': { 'thing': true } })
     })
 
     it('should use the server config if set', () => {
@@ -94,7 +97,8 @@ describe('plugins/util/web', () => {
           validateStatus: code => false,
           hooks: {
             request: () => 'test'
-          }
+          },
+          expandRouteParameters: { '/path': { 'thing': true } }
         }
       })
 
@@ -102,6 +106,7 @@ describe('plugins/util/web', () => {
       expect(config.validateStatus(200)).to.equal(false)
       expect(config).to.have.property('hooks')
       expect(config.hooks.request()).to.equal('test')
+      expect(config.expandRouteParameters).to.deep.equal({ '/path': { 'thing': true } })
     })
 
     it('should prioritize the server config over the shared config', () => {


### PR DESCRIPTION
Provides a new configuration option to allow route parameter expansion in Zipkin operation names.

~Waiting on https://github.com/signalfx/signalfx-nodejs-tracing/pull/8 though reviews are appreciated.~

edit: Updated for ci and improved tests.