### PR TITLE
Fix mysql Pool regression and test scope creep

### DIFF
--- a/src/plugins/mysql.js
+++ b/src/plugins/mysql.js
@@ -43,6 +43,15 @@ function createWrapQuery (tracer, config) {
   }
 }
 
+function createWrapGetConnection (tracer, config) {
+  return function wrapGetConnection (getConnection) {
+    return function getConnectionWithTrace (cb) {
+      const scope = tracer.scope()
+      return scope.bind(getConnection).call(this, scope.bind(cb))
+    }
+  }
+}
+
 function wrapCallback (tracer, span, parent, done) {
   return tracer.scope().bind((err, res) => {
     if (err) {
@@ -67,6 +76,14 @@ function unpatchConnection (Connection) {
   this.unwrap(Connection.prototype, 'query')
 }
 
+function patchPool (Pool, tracer, config) {
+  this.wrap(Pool.prototype, 'getConnection', createWrapGetConnection(tracer, config))
+}
+
+function unpatchPool (Pool) {
+  this.unwrap(Pool.prototype, 'getConnection')
+}
+
 module.exports = [
   {
     name: 'mysql',
@@ -74,5 +91,12 @@ module.exports = [
     versions: ['>=2'],
     patch: patchConnection,
     unpatch: unpatchConnection
+  },
+  {
+    name: 'mysql',
+    file: 'lib/Pool.js',
+    versions: ['>=2'],
+    patch: patchPool,
+    unpatch: unpatchPool
   }
 ]

--- a/test/plugins/mysql.spec.js
+++ b/test/plugins/mysql.spec.js
@@ -48,8 +48,6 @@ describe('Plugin', () => {
           const span = tracer.startSpan('test')
 
           tracer.scope().activate(span, () => {
-            const span = tracer.scope().active()
-
             connection.query('SELECT 1 + 1 AS solution', () => {
               expect(tracer.scope().active()).to.equal(span)
               done()
@@ -208,6 +206,18 @@ describe('Plugin', () => {
           pool.query('SELECT 1 + 1 AS solution', () => {
             expect(tracer.scope().active()).to.be.null
             done()
+          })
+        })
+
+        it('should propagate context to callbacks', done => {
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
+
+          const span = tracer.startSpan('test')
+          tracer.scope().activate(span, () => {
+            pool.query('SELECT 1 + 1 AS solution', () => {
+              expect(tracer.scope().active()).to.equal(span)
+              done()
+            })
           })
         })
       })


### PR DESCRIPTION
Upstream updates to mysql instrumentation introduced a regression for pooled queries having incorrect parent, where the parent is the active span on initial connection creation.  These changes bind to the context of the pool's query instead.

Also including null span mocha hook binding as there is noisy neighbor scope creep without.