### PR TITLE
Expand scope testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,15 @@ node-core-base: &node-core-base
   resource_class: small
   steps:
     - checkout
-    - run:
+    - &run-yarn-versions
+      run:
         name: Versions
         command: yarn versions
     - &restore-yarn-cache
       restore_cache:
         key: yarn-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package.json" }}
-    - run:
+    - &run-yarn-install
+      run:
         name: Install dependencies
         command: yarn install --ignore-engines
     - &save-yarn-cache
@@ -22,10 +24,12 @@ node-core-base: &node-core-base
         paths:
           - ./node_modules
           - ./yarn.lock
-    - run:
+    - &run-unit-tests
+      run:
         name: Unit tests
         command: yarn test:core
-    - run:
+    - &run-benchmark
+      run:
         name: Benchmark
         command: yarn bench
 
@@ -96,16 +100,46 @@ jobs:
     <<: *node-core-base
     docker:
       - image: node:8
+    steps:
+      - checkout
+      - *run-yarn-versions
+      - *restore-yarn-cache
+      - *run-yarn-install
+      - *save-yarn-cache
+      - *run-unit-tests
+      - *run-benchmark
+      - &run-async-tests
+        run:
+          name: Async scope tests
+          command: yarn test:async
 
   node-core-10:
     <<: *node-core-base
     docker:
       - image: node:10
+    steps:
+      - checkout
+      - *run-yarn-versions
+      - *restore-yarn-cache
+      - *run-yarn-install
+      - *save-yarn-cache
+      - *run-unit-tests
+      - *run-benchmark
+      - *run-async-tests
 
   node-core-latest:
     <<: *node-core-base
     docker:
       - image: node
+    steps:
+      - checkout
+      - *run-yarn-versions
+      - *restore-yarn-cache
+      - *run-yarn-install
+      - *save-yarn-cache
+      - *run-unit-tests
+      - *run-benchmark
+      - *run-async-tests
 
   node-leaks:
     docker:

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "startContainers": "docker-compose up -d -V --remove-orphans --force-recreate",
     "tdd": "yarn services && NO_DEPRECATION=* mocha --watch 'test/setup/**/*.js'",
     "test": "SERVICES=* yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit 'test/setup/all.js' 'test/**/*.spec.js'",
-    "test:core": "mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
+    "test:core": "mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --exclude \"test/scope/async/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
     "test:plugins": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit --file \"test/setup/all.js\" \"test/plugins/@($(echo $PLUGINS)).spec.js\" \"test/plugins/@($(echo $PLUGINS))/**/*.spec.js\"",
+    "test:async": "mocha --exit --file test/setup/core.js \"test/scope/async/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules|plugins)/**/}/*.js'",
     "leak:plugins": "yarn services && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape \"test/leak/plugins/@($(echo $PLUGINS)).js\""
   },

--- a/test/scope/async/.eslintrc.json
+++ b/test/scope/async/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "../../.eslintrc.json"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2017
+  }
+}

--- a/test/scope/async/async.spec.js
+++ b/test/scope/async/async.spec.js
@@ -1,0 +1,100 @@
+'use strict'
+
+const Scope = require('../../../src/scope/new/scope')
+const Span = require('opentracing').Span
+
+wrapIt()
+
+describe('Async Functions', () => {
+  let scope
+  let spanOne
+  let spanTwo
+  let spanThree
+  let expectOne
+  let expectTwo
+  let expectThree
+
+  beforeEach(() => {
+    scope = new Scope()
+    spanOne = new Span()
+    spanTwo = new Span()
+    spanThree = new Span()
+    expectOne = async () => { await expect(scope.active()).to.equal(spanOne) }
+    expectTwo = async () => { await expect(scope.active()).to.equal(spanTwo) }
+    expectThree = async () => { await expect(scope.active()).to.equal(spanThree) }
+  })
+
+  describe('Nested async functions', () => {
+    it('should assume active from calling context', done => {
+      scope.activate(spanOne, () => {
+        async function one () {
+          await expect(scope.active()).to.be.null
+        }
+        global.one = one
+      })
+      global.one()
+
+      async function two () {
+        scope.activate(spanOne, async () => {
+          await expectOne()
+          await scope.bind(expectOne)()
+          await setImmediate(expectOne)
+
+          scope.activate(spanTwo, async () => {
+            expectTwo()
+            scope.bind(expectTwo)()
+            await setImmediate(expectTwo)
+          })
+
+          await scope.activate(spanThree, async () => {
+            expectThree()
+            scope.bind(expectThree)()
+            await setImmediate(expectThree)
+
+            scope.activate(spanOne, async () => {
+              expectOne()
+              scope.bind(expectOne)()
+              setImmediate(expectOne)
+
+              scope.activate(spanTwo, async () => { await expectTwo() })
+              await scope.activate(spanThree, async () => { await expectThree() })
+
+              setImmediate(async () => {
+                setImmediate(expectOne)
+                await scope.bind(expectOne)()
+
+                scope.activate(spanTwo, async () => { await expectTwo() })
+                scope.activate(spanThree, async () => { await expectThree() })
+
+                setImmediate(() => {
+                  setImmediate(() => {
+                    expectOne()
+                    scope.bind(expectOne)()
+                    setImmediate(async () => {
+                      await expectOne()
+                      done()
+                    })
+                  })
+                })
+              })
+
+              expectOne()
+              scope.bind(expectOne)()
+              setImmediate(expectOne)
+            })
+
+            expectThree()
+            scope.bind(expectThree)()
+            setImmediate(expectThree)
+          })
+
+          await expectOne()
+          await scope.bind(expectOne)()
+          setImmediate(expectOne)
+        })
+      }
+      two().then(global.one)
+      global.one()
+    })
+  })
+})

--- a/test/scope/callbacks.spec.js
+++ b/test/scope/callbacks.spec.js
@@ -1,0 +1,127 @@
+'use strict'
+
+const Scope = require('../../src/scope/new/scope')
+const Span = require('opentracing').Span
+
+wrapIt()
+
+describe('Callbacks', () => {
+  let scope
+  let spanOne
+  let spanTwo
+  let spanThree
+  let expectOne
+  let expectTwo
+  let expectThree
+  let expectNull
+
+  beforeEach(() => {
+    scope = new Scope()
+    spanOne = new Span()
+    spanTwo = new Span()
+    spanThree = new Span()
+    expectOne = () => { expect(scope.active()).to.equal(spanOne) }
+    expectTwo = () => { expect(scope.active()).to.equal(spanTwo) }
+    expectThree = () => { expect(scope.active()).to.equal(spanThree) }
+    expectNull = () => { expect(scope.active()).to.be.null }
+  })
+
+  describe('Nested callbacks with multiple spans', () => {
+    it('activate should set active for callbacks without affecting parent context', done => {
+      expectNull()
+      scope.activate(spanOne, () => {
+        expectOne()
+        scope.bind(expectOne)()
+        setImmediate(expectOne)
+
+        scope.activate(spanTwo, () => {
+          expectTwo()
+          scope.bind(expectTwo)()
+          setImmediate(expectTwo)
+        })
+
+        scope.activate(spanThree, () => {
+          expectThree()
+          scope.bind(expectThree)()
+          setImmediate(expectThree)
+
+          scope.activate(spanOne, () => {
+            setImmediate(expectOne)
+
+            scope.activate(spanTwo, expectTwo)
+            scope.bind(expectThree, spanThree)()
+
+            setImmediate(() => {
+              scope.bind(expectOne)()
+              scope.bind(expectTwo, spanTwo)()
+              scope.activate(spanThree, expectThree)
+
+              function finish () {
+                expectOne()
+                scope.bind(expectOne)()
+                scope.activate(spanThree, () => {
+                  setImmediate(() => {
+                    expectThree()
+                    done()
+                  })
+                })
+              }
+
+              function loop (count) {
+                if (count === 100) {
+                  return setImmediate(finish)
+                }
+                expectOne()
+                scope.bind(expectTwo, spanTwo)()
+                scope.activate(spanThree, expectThree)
+                setImmediate(() => { loop(count + 1) })
+              }
+
+              loop(1)
+            })
+
+            expectOne()
+            scope.bind(expectOne)()
+            setImmediate(expectOne)
+          })
+
+          expectThree()
+          scope.bind(expectThree)()
+          setImmediate(expectThree)
+        })
+
+        expectOne()
+        scope.bind(expectOne)()
+        setImmediate(expectOne)
+      })
+      expectNull()
+    })
+
+    it('Active span should be of calling context despite where function defined', done => {
+      let definedInOne
+      let definedInTwo
+      expect(scope.active()).to.be.null
+      scope.activate(spanOne, () => {
+        definedInOne = () => { setImmediate(expectNull) }
+
+        function activeSpanTest () {
+          expectNull()
+          scope.activate(spanTwo, () => {
+            setImmediate(expectTwo)
+            definedInTwo = () => {
+              setImmediate(() => {
+                expectNull()
+                done()
+              })
+            }
+          })
+        }
+
+        global.activeSpanTest = activeSpanTest
+      })
+      global.activeSpanTest()
+      definedInOne()
+      definedInTwo()
+    })
+  })
+})

--- a/test/scope/events.spec.js
+++ b/test/scope/events.spec.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const Scope = require('../../src/scope/new/scope')
+const Span = require('opentracing').Span
+const EventEmitter = require('events').EventEmitter
+const semver = require('semver')
+
+wrapIt()
+
+describe('Events', () => {
+  let scope
+  let spanOne
+  let spanTwo
+  let spanThree
+  let expectOne
+  let expectThree
+
+  beforeEach(() => {
+    scope = new Scope()
+    spanOne = new Span()
+    spanTwo = new Span()
+    spanThree = new Span()
+    expectOne = () => { expect(scope.active()).to.equal(spanOne) }
+    expectThree = () => { expect(scope.active()).to.equal(spanThree) }
+  })
+
+  describe('EventEmitters', () => {
+    it('should set active for listeners when bound and assume context otherwise', done => {
+      const boundToOneInside = new EventEmitter()
+      expect(scope.active()).to.be.null
+      const test = new Promise(resolve => {
+        scope.activate(spanOne, () => {
+          let expected = spanOne
+          const dynamicExpect = () => { expect(scope.active()).to.equal(expected) }
+
+          const implicitOne = new EventEmitter()
+          implicitOne.on('test', expectOne)
+          implicitOne.emit('test')
+
+          let implicitTwo
+          scope.activate(spanTwo, () => {
+            implicitTwo = new EventEmitter()
+            expected = spanTwo
+            if (semver.satisfies(process.version, '>=6')) {
+              implicitTwo.prependListener('test', dynamicExpect)
+            } else {
+              implicitTwo.addListener('test', dynamicExpect)
+            }
+            implicitTwo.emit('test')
+          })
+          // Unbound EventEmitter's listener assume currently active span
+          expected = spanOne
+          implicitTwo.emit('test')
+
+          scope.activate(spanThree, () => {
+            expected = spanThree
+            implicitTwo.emit('test')
+
+            const explicitOne = new EventEmitter()
+            scope.bind(explicitOne, spanOne)
+            expectThree() // binding EventEmitter doesn't affect active span
+
+            explicitOne.once('test', expectOne)
+            explicitOne.emit('test')
+
+            scope.bind(explicitOne, spanTwo) // rebinding isn't possible
+            scope.activate(spanOne, () => {
+              expectOne()
+              expected = spanOne
+              implicitTwo.emit('test')
+
+              if (semver.satisfies(process.version, '>=6')) {
+                explicitOne.prependOnceListener('test', expectOne)
+              } else {
+                explicitOne.once('test', expectOne)
+              }
+
+              explicitOne.emit('test')
+
+              setImmediate(() => {
+                setImmediate(() => {
+                  setImmediate(() => {
+                    implicitTwo.emit('test')
+                    expectOne()
+                    scope.bind(boundToOneInside)
+                    boundToOneInside.on('test', expectOne)
+                    boundToOneInside.on('done', done)
+                    resolve()
+                  })
+                })
+              })
+              expectOne()
+            })
+            expectThree()
+          })
+          expectOne()
+        })
+      })
+      test.then(() => {
+        expect(scope.active()).to.be.null
+        boundToOneInside.emit('test')
+        boundToOneInside.emit('test')
+        boundToOneInside.emit('done')
+      })
+    })
+  })
+})

--- a/test/scope/promises.spec.js
+++ b/test/scope/promises.spec.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const Scope = require('../../src/scope/new/scope')
+const Span = require('opentracing').Span
+
+wrapIt()
+
+describe('Promises', () => {
+  let scope
+  let spanOne
+  let spanTwo
+  let spanThree
+  let expectOne
+  let expectTwo
+  let expectThree
+  let expectNull
+
+  beforeEach(() => {
+    scope = new Scope()
+    spanOne = new Span()
+    spanTwo = new Span()
+    spanThree = new Span()
+    expectOne = () => { expect(scope.active()).to.equal(spanOne) }
+    expectTwo = () => { expect(scope.active()).to.equal(spanTwo) }
+    expectThree = () => { expect(scope.active()).to.equal(spanThree) }
+    expectNull = () => { expect(scope.active()).to.be.null }
+  })
+
+  describe('Nested promises', () => {
+    it('bind should set active for then, with Promise inheriting current active', done => {
+      let innerBoundToTwo
+      let outerBoundToTwo
+      expectNull()
+
+      const test = new Promise(resolve => {
+        scope.activate(spanOne, () => {
+          Promise.resolve().then(expectOne).then(expectOne).catch(done)
+          Promise.reject(new Error('test')).then(null, scope.bind(expectOne)).then(expectOne).catch(done)
+          Promise.resolve().then(() => setImmediate(expectOne)).then(expectOne).catch(done)
+
+          const boundToThree = scope.bind(Promise.resolve(), spanThree)
+          const boundToTwo = scope.bind(boundToThree.then(expectThree), spanTwo)
+          boundToTwo.then(expectTwo).then(expectOne).then(expectOne).catch(done)
+
+          scope.activate(spanThree, () => {
+            const boundToOne = scope.bind(Promise.resolve(), spanOne)
+            const alsoBoundToTwo = scope.bind(boundToOne.then(expectOne), spanTwo)
+            alsoBoundToTwo.then(expectTwo).then(expectThree).then(expectThree).catch(done)
+
+            const alsoBoundToOne = scope.bind(Promise.all([Promise.resolve(), Promise.resolve()]), spanOne)
+            alsoBoundToOne.then(expectOne).then(expectThree).catch(done)
+
+            outerBoundToTwo = new Promise((resolve, reject) => {
+              expectThree()
+
+              scope.activate(spanOne, () => {
+                expectOne()
+                scope.bind(expectOne)()
+                setImmediate(expectOne)
+
+                scope.activate(spanTwo, expectTwo)
+                scope.activate(spanThree, expectThree)
+
+                innerBoundToTwo = Promise.resolve()
+                scope.bind(innerBoundToTwo, spanTwo)
+
+                setImmediate(() => {
+                  setImmediate(expectOne)
+                  scope.bind(expectOne)()
+
+                  scope.activate(spanTwo, expectTwo)
+                  scope.activate(spanThree, expectThree)
+
+                  setImmediate(() => {
+                    setImmediate(() => {
+                      expectOne()
+                      scope.bind(expectOne)()
+                      setImmediate(() => {
+                        expectOne()
+                        resolve()
+                      })
+                    })
+                  })
+                })
+
+                expectOne()
+                scope.bind(expectOne)()
+                setImmediate(expectOne)
+              })
+            })
+
+            scope.bind(outerBoundToTwo, spanTwo)
+            outerBoundToTwo.then(expectTwo).then(expectThree).catch(done)
+            expectThree()
+            resolve()
+          })
+
+          expectOne()
+        })
+      })
+
+      expectNull()
+      innerBoundToTwo.then(expectTwo).then(expectNull).catch(done)
+      test.then(expectNull).then(done).catch(done)
+    })
+  })
+})


### PR DESCRIPTION
Provides some additional scope-examining suites that confirm nested activate/bind behavior with multiple spans conforms to expectations on all bindable types.  I've tried to make things pretty clear, though they are a bit rambling in the name of exercising otherwise untested paths.