### PR TITLE
Dont inject on NoopSpan submission

### DIFF
--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -12,7 +12,7 @@ const pkg = require('../package.json')
 
 const name = `${os.platform()}-${os.arch()}`
 
-if (process.env.DD_NATIVE_METRICS !== 'false') {
+if (process.env.DD_NATIVE_METRICS === 'true') {
   download(`v${pkg.version}`)
     .catch(() => getLatestTag().then(download))
     .then(persist)

--- a/src/opentracing/propagation/b3_text_map.js
+++ b/src/opentracing/propagation/b3_text_map.js
@@ -20,7 +20,12 @@ const logKeys = [traceIdKey, spanIdKey, parentIdKey, sampledKey]
 
 class B3TextMapPropagator {
   inject (spanContext, carrier) {
-    carrier[traceIdKey] = idToHex(spanContext._traceId)
+    const traceId = idToHex(spanContext._traceId)
+    // Don't inject trace data from NoopSpan
+    if (traceId === '0000000000000000') {
+      return
+    }
+    carrier[traceIdKey] = traceId
     carrier[spanIdKey] = idToHex(spanContext._spanId)
 
     const parentId = spanContext._parentId


### PR DESCRIPTION
Prevents injecting NoopSpan context via B3 by filtering its trace id.  Also disables default installation of metric extensions.