### PR TITLE
Use original async hooks execution id function if necessary

### DIFF
--- a/src/scope/new/scope.js
+++ b/src/scope/new/scope.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const asyncHooks = require('../async_hooks')
-const executionAsyncId = asyncHooks.executionAsyncId
+const executionAsyncId = asyncHooks.executionAsyncId || asyncHooks.currentId
 const Base = require('./base')
 const platform = require('../../platform')
 


### PR DESCRIPTION
For node 8.0.0 users `executionAsyncId` was originally named `currentId`: https://github.com/nodejs/node/blob/0d8021e5a4cf0a6aa3a700a361f6d42c2894f2ba/lib/async_hooks.js#L183.  This was changed in 8.1.0.