### PR TITLE
CI and test corrections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,40 +463,6 @@ jobs:
       - store_artifacts:
           path: ./addons-linux-x32.tgz
 
-  prebuild-darwin-x64:
-    macos:
-      xcode: "10.2.0"
-    working_directory: ~/dd-trace-js
-    resource_class: small
-    environment:
-      - ARCH=x64
-    steps:
-      - checkout
-      - *yarn-versions
-      - *restore-yarn-cache
-      - *yarn-install
-      - *save-yarn-cache
-      - *yarn-prebuild
-      - store_artifacts:
-          path: ./addons-darwin-x64.tgz
-
-  prebuild-darwin-x32:
-    macos:
-      xcode: "10.2.0"
-    working_directory: ~/dd-trace-js
-    resource_class: small
-    environment:
-      - ARCH=x32
-    steps:
-      - checkout
-      - *yarn-versions
-      - *restore-yarn-cache
-      - *yarn-install
-      - *save-yarn-cache
-      - *yarn-prebuild
-      - store_artifacts:
-          path: ./addons-darwin-x32.tgz
-
   alpine:
     docker:
       - image: node:10-alpine
@@ -581,18 +547,6 @@ workflows:
                 - master
                 - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
       - prebuild-linux-x32:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-darwin-x64:
-          filters:
-            branches:
-              only:
-                - master
-                - /v\d+\.\d+\.\d+([-a-z]+\.\d+)?/
-      - prebuild-darwin-x32:
           filters:
             branches:
               only:

--- a/test/opentracing/span_context.spec.js
+++ b/test/opentracing/span_context.spec.js
@@ -28,7 +28,8 @@ describe('SpanContext', () => {
     }
     const spanContext = new SpanContext(props)
 
-    expect(spanContext).to.deep.equal({
+    // Support deep-eql for OpenTracing 0.14.4 SpanContext prototype changes and Node 4 & 6
+    expect(spanContext).to.deep.equal(Object.setPrototypeOf({
       _traceId: '123',
       _spanId: '456',
       _parentId: '789',
@@ -43,7 +44,7 @@ describe('SpanContext', () => {
         started: ['span1', 'span2'],
         finished: ['span1']
       }
-    })
+    }, Object.getPrototypeOf(spanContext)))
   })
 
   it('should have the correct default values', () => {
@@ -69,7 +70,7 @@ describe('SpanContext', () => {
       spanId: expected.spanId
     })
 
-    expect(spanContext).to.deep.equal({
+    expect(spanContext).to.deep.equal(Object.setPrototypeOf({
       _traceId: '123',
       _spanId: '456',
       _parentId: null,
@@ -84,7 +85,7 @@ describe('SpanContext', () => {
         started: [],
         finished: []
       }
-    })
+    }, Object.getPrototypeOf(spanContext)))
   })
 
   describe('toTraceId()', () => {

--- a/test/plugins/elasticsearch.spec.js
+++ b/test/plugins/elasticsearch.spec.js
@@ -50,8 +50,8 @@ describe('Plugin', () => {
         it('should sanitize ID and query parameter containing request', done => {
           agent
             .use(traces => {
-              expect(traces[0][0]).to.have.property('name', 'POST /docs/test/?')
-              expect(traces[0][0].meta).to.have.property('elasticsearch.url', `/docs/test/${randId}`)
+              expect(traces[0][0]).to.have.property('name', 'POST /docs/_doc/?')
+              expect(traces[0][0].meta).to.have.property('elasticsearch.url', `/docs/_doc/${randId}`)
             })
             .then(done)
             .catch(done)
@@ -60,7 +60,7 @@ describe('Plugin', () => {
           client.index({
             index: 'docs',
             id: randId,
-            type: 'test',
+            type: '_doc',
             opType: 'create',
             query: 'query',
             body: {}


### PR DESCRIPTION
These changes remove a currently unsupported instance type from our CI runs and update the ES tests to account for the changed index api to account for the ongoing removal of types.