### PR TITLE
Express synthesized context

### DIFF
--- a/test/leak/plugins/express.js
+++ b/test/leak/plugins/express.js
@@ -19,7 +19,7 @@ test('express plugin should not leak', t => {
     })
 
     const listener = app.listen(port, '127.0.0.1', () => {
-      profile(t, operation).then(() => listener.close())
+      profile(t, operation, 2000).then(() => listener.close())
 
       function operation (done) {
         axios.get(`http://localhost:${port}`).then(done)

--- a/test/plugins/adonis.spec.js
+++ b/test/plugins/adonis.spec.js
@@ -304,7 +304,7 @@ describe('Plugin', () => {
             expect(spans[1]).to.have.property('service', 'test')
             expect(spans[1]).to.have.property('name', 'Middleware/AppMiddleware')
             expect(spans[1].meta).to.have.property('component', 'adonis')
-            expect(spans[1].parent_id.toString()).to.equal(spans[2].trace_id.toString())
+            expect(spans[1].parent_id.toString()).to.equal(spans[2].span_id.toString())
 
             expect(spans[2]).to.have.property('service', 'test')
             expect(spans[2]).to.have.property('name', `/api/user`)

--- a/test/plugins/graphql.spec.js
+++ b/test/plugins/graphql.spec.js
@@ -1295,10 +1295,11 @@ describe('Plugin', () => {
         let mergeSchemas
         let makeExecutableSchema
 
-        before(() => {
+        before(function (done) {
+          this.timeout(5000)
           tracer = require('../..')
 
-          return agent.load(plugin, 'graphql')
+          agent.load(plugin, 'graphql')
             .then(() => {
               graphql = require(`../../versions/graphql@${version}`).get()
 
@@ -1308,6 +1309,7 @@ describe('Plugin', () => {
               runQuery = apolloCore.runQuery
               mergeSchemas = graphqlTools.mergeSchemas
               makeExecutableSchema = graphqlTools.makeExecutableSchema
+              done()
             })
         })
 

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -71,6 +71,7 @@ describe('plugins/util/web', () => {
       expect(config.hooks).to.have.property('request')
       expect(config.hooks.request).to.be.a('function')
       expect(config.expandRouteParameters).to.be.an('object')
+      expect(config.synthesizeRequestingContext).to.be.an('object')
     })
 
     it('should use the shared config if set', () => {
@@ -80,7 +81,8 @@ describe('plugins/util/web', () => {
         hooks: {
           request: () => 'test'
         },
-        expandRouteParameters: { '/path': { 'thing': true } }
+        expandRouteParameters: { '/path': { 'thing': true } },
+        synthesizeRequestingContext: { '/path': true }
       })
 
       expect(config.headers).to.include('test')
@@ -88,6 +90,7 @@ describe('plugins/util/web', () => {
       expect(config).to.have.property('hooks')
       expect(config.hooks.request()).to.equal('test')
       expect(config.expandRouteParameters).to.deep.equal({ '/path': { 'thing': true } })
+      expect(config.synthesizeRequestingContext).to.deep.equal({ '/path': true })
     })
 
     it('should use the server config if set', () => {
@@ -98,7 +101,8 @@ describe('plugins/util/web', () => {
           hooks: {
             request: () => 'test'
           },
-          expandRouteParameters: { '/path': { 'thing': true } }
+          expandRouteParameters: { '/path': { 'thing': true } },
+          synthesizeRequestingContext: { '/path': true }
         }
       })
 
@@ -107,6 +111,7 @@ describe('plugins/util/web', () => {
       expect(config).to.have.property('hooks')
       expect(config.hooks.request()).to.equal('test')
       expect(config.expandRouteParameters).to.deep.equal({ '/path': { 'thing': true } })
+      expect(config.synthesizeRequestingContext).to.deep.equal({ '/path': true })
     })
 
     it('should prioritize the server config over the shared config', () => {


### PR DESCRIPTION
Adds a `synthesizeRequestingContext` express configuration option to allow custom logic to retroactively create a parent span for a request handler where client instrumentation is infeasible.  The trace and synthesized span ids are available in request middleware and handlers via:

```javascript
function handle (req, res, next) {
  const traceId = req.sfx.traceId
  const spanId = req.sfx.spanId
}
```

Also increases flakey graphql hook timeout.