### PR TITLE
Ensure synthesized contexts obey sampling

### DIFF
--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -72,7 +72,9 @@ class SignalFxTracer extends Tracer {
 
     if (type === REFERENCE_NOOP) return noopSpan
     if (parent && parent === noopSpan.context()) return noopSpan
-    if (!parent && !this._sampler.isSampled()) return noopSpan
+    const isSampled = this._sampler.isSampled()
+    if (!parent && !isSampled) return noopSpan
+    if (parent && parent.isSynthesized && !isSampled) return noopSpan
 
     const tags = {
       'service.name': this._service

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -354,6 +354,7 @@ function expandRouteParameters (httpRoute, req) {
 function synthesizedSpanContext (req) {
   const traceId = platform.id()
   const spanContext = new SpanContext({ traceId, spanId: traceId })
+  Object.defineProperty(spanContext, 'isSynthesized', { value: true })
   const resId = idToHex(traceId)
   Object.defineProperty(req, 'sfx', { value: { traceId: resId, spanId: resId } })
   return spanContext

--- a/test/leak/plugins/express.js
+++ b/test/leak/plugins/express.js
@@ -19,7 +19,7 @@ test('express plugin should not leak', t => {
     })
 
     const listener = app.listen(port, '127.0.0.1', () => {
-      profile(t, operation, 2000).then(() => listener.close())
+      profile(t, operation).then(() => listener.close())
 
       function operation (done) {
         axios.get(`http://localhost:${port}`).then(done)


### PR DESCRIPTION
Without detecting that a context has been synthesized, the tracer will report all spans with synthesized parents as if they were propagation-parented (sampling guaranteed).