### PR TITLE
Expose writer's flush promise

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -168,6 +168,8 @@ const carrier = {}
 tracer.inject(span || span.context(), HTTP_HEADERS, carrier);
 context = tracer.extract(HTTP_HEADERS, carrier);
 
+tracer.flush().then(() => {})
+
 traceId = context.toTraceId();
 spanId = context.toSpanId();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,11 @@ export declare interface Tracer extends opentracing.Tracer {
    */
   wrap<T = (...args: any[]) => any>(name: string, fn: T): T;
   wrap<T = (...args: any[]) => any>(name: string, options: TraceOptions & SpanOptions, fn: T): T;
+
+  /**
+   * Calls writer's flush() and returns its requesting promise
+   */
+  flush<T>(): Promise<T>;
 }
 
 export declare interface TraceOptions {

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -44,6 +44,10 @@ class NoopTracer extends Tracer {
   _startSpan (name, options) {
     return this._span
   }
+
+  flush () {
+    return Promise.resolve()
+  }
 }
 
 module.exports = NoopTracer

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -113,6 +113,14 @@ class SignalFxTracer extends Tracer {
       return null
     }
   }
+
+  flush () {
+    const flushed = this._writer.flush()
+    if (flushed == null) {
+      return Promise.resolve()
+    }
+    return flushed
+  }
 }
 
 function getReferences (references) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -138,6 +138,10 @@ class Tracer extends BaseTracer {
   bindEmitter () {
     this._deprecate('bindEmitter')
   }
+
+  flush () {
+    return this._tracer.flush.apply(this._tracer, arguments)
+  }
 }
 
 module.exports = Tracer

--- a/src/writer.js
+++ b/src/writer.js
@@ -55,10 +55,11 @@ class Writer {
     if (this._queue.length > 0) {
       const data = platform.msgpack.prefix(this._queue)
 
-      this._request(data, this._queue.length)
+      const request = this._request(data, this._queue.length)
 
       this._queue = []
       this._size = 0
+      return request
     }
   }
 
@@ -86,7 +87,7 @@ class Writer {
 
     log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
-    platform
+    return platform
       .request(Object.assign({ data }, options))
       .then(res => {
         log.debug(`Response from the agent: ${res}`)

--- a/src/zipkin/writer.js
+++ b/src/zipkin/writer.js
@@ -29,10 +29,11 @@ class ZipkinV2Writer extends Writer {
       })
       const data = JSON.stringify(spans)
 
-      this._request(data)
+      const request = this._request(data)
 
       this._queue = []
       this._size = 0
+      return request
     }
   }
 
@@ -47,7 +48,7 @@ class ZipkinV2Writer extends Writer {
     }
     log.debug(() => `Request to the agent: ${JSON.stringify(options)}`)
 
-    platform
+    return platform
       .request(Object.assign({ data }, options))
       .catch(e => log.error(e))
   }

--- a/test/noop.spec.js
+++ b/test/noop.spec.js
@@ -51,4 +51,10 @@ describe('NoopTracer', () => {
       expect(span.context().toSpanId()).to.equal('0')
     })
   })
+
+  describe('flush', () => {
+    it('should return a Promise', () => {
+      expect(tracer.flush()).to.be.a('Promise')
+    })
+  })
 })

--- a/test/opentracing/tracer.spec.js
+++ b/test/opentracing/tracer.spec.js
@@ -38,7 +38,9 @@ describe('Tracer', () => {
     }
     PrioritySampler = sinon.stub().returns(prioritySampler)
 
-    writer = {}
+    writer = {
+      flush: sinon.spy()
+    }
     Writer = sinon.stub().returns(writer)
 
     recorder = {
@@ -99,6 +101,12 @@ describe('Tracer', () => {
     expect(Writer).to.have.been.calledWith(prioritySampler, config.url)
     expect(Recorder).to.have.been.calledWith(writer, config.flushInterval)
     expect(recorder.init).to.have.been.called
+  })
+
+  it('should support manual flushing', () => {
+    tracer = new Tracer(config)
+    tracer.flush()
+    expect(writer.flush).to.have.been.called
   })
 
   it('should support sampling', () => {

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -22,7 +22,8 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('tracer'),
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
-      scopeManager: sinon.stub().returns('scopeManager')
+      scopeManager: sinon.stub().returns('scopeManager'),
+      flush: sinon.stub().returns('flush')
     }
 
     noop = {
@@ -33,7 +34,8 @@ describe('TracerProxy', () => {
       inject: sinon.stub().returns('noop'),
       extract: sinon.stub().returns('spanContext'),
       currentSpan: sinon.stub().returns('current'),
-      scopeManager: sinon.stub().returns('scopeManager')
+      scopeManager: sinon.stub().returns('scopeManager'),
+      flush: sinon.stub().returns('flush')
     }
 
     instrumenter = {
@@ -227,6 +229,15 @@ describe('TracerProxy', () => {
         expect(returnValue).to.equal('scopeManager')
       })
     })
+
+    describe('flush', () => {
+      it('should call the underlying NoopTracer', () => {
+        const returnValue = proxy.flush()
+
+        expect(noop.flush).to.have.been.called
+        expect(returnValue).to.equal('flush')
+      })
+    })
   })
 
   describe('initialized', () => {
@@ -321,6 +332,15 @@ describe('TracerProxy', () => {
 
         expect(tracer.scopeManager).to.have.been.called
         expect(returnValue).to.equal('scopeManager')
+      })
+    })
+
+    describe('flush', () => {
+      it('should call the underlying SignalFxTracer', () => {
+        const returnValue = proxy.flush()
+
+        expect(tracer.flush).to.have.been.called
+        expect(returnValue).to.equal('flush')
       })
     })
   })

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -123,15 +123,17 @@ describe('Writer', () => {
 
   describe('flush', () => {
     it('should skip flushing if empty', () => {
-      writer.flush()
+      const flushed = writer.flush()
 
+      expect(flushed).to.be.undefined
       expect(platform.request).to.not.have.been.called
     })
 
     it('should empty the internal queue', () => {
       writer.append(span)
-      writer.flush()
+      const flushed = writer.flush()
 
+      expect(flushed).to.be.a('Promise')
       expect(writer.length).to.equal(0)
     })
 


### PR DESCRIPTION
In environments like lambda it can be helpful to manually flush the tracer.  These changes provide an accessor for writer's flush method that now returns the requesting promise.