### PR TITLE
Install working nock for Node <8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "startContainers": "docker-compose up -d -V --remove-orphans --force-recreate",
     "tdd": "yarn services && NO_DEPRECATION=* mocha --watch 'test/setup/**/*.js'",
     "test": "SERVICES=* yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit 'test/setup/all.js' 'test/**/*.spec.js'",
-    "test:core": "mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --exclude \"test/scope/async/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
+    "test:core": "yarn dev:dependencies && mocha --exit --exclude \"test/plugins/*.spec.js\" --exclude \"test/plugins/http/*.spec.js\" --exclude \"test/scope/async/*.spec.js\" --file test/setup/core.js \"test/**/*.spec.js\"",
     "test:plugins": "yarn services && NO_DEPRECATION=* cov8 --include \"src/**/*.js\" -- mocha --exit --file \"test/setup/all.js\" \"test/plugins/@($(echo $PLUGINS)).spec.js\" \"test/plugins/@($(echo $PLUGINS))/**/*.spec.js\"",
     "test:async": "mocha --exit --file test/setup/core.js \"test/scope/async/*.spec.js\"",
     "leak:core": "node ./scripts/install_plugin_modules && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape 'test/leak/{,!(node_modules|plugins)/**/}/*.js'",
-    "leak:plugins": "yarn services && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape \"test/leak/plugins/@($(echo $PLUGINS)).js\""
+    "leak:plugins": "yarn services && (cd test/leak && yarn) && NODE_PATH=./test/leak/node_modules node --no-warnings ./node_modules/.bin/tape \"test/leak/plugins/@($(echo $PLUGINS)).js\"",
+    "dev:dependencies": "node ./scripts/dev_dependencies.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/dev_dependencies.js
+++ b/scripts/dev_dependencies.js
@@ -1,0 +1,12 @@
+const exec = require('./helpers/exec')
+
+function installNock () {
+  // Required version of nock for 12+ doesn't support node <8.
+  // Manually install last supported version until 4 and 6 support are dropped
+  if (process.versions.node.split('.')[0] < 8) {
+    exec('yarn remove --force --ignore-engines nock')
+    exec('yarn add --dev -E --ignore-engines nock@9.6.1')
+  }
+}
+
+installNock()


### PR DESCRIPTION
Attempt to undo breaking change for Node 12+ test support.  bisect is showing that this commit is needed: https://github.com/nock/nock/commit/2647af72d40cd5ace3f33a8a5442f8ad891622dd.