### PR TITLE
Knex auto-instrumentation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,7 @@ workflows:
       - node-graphql
       - node-hapi
       - node-http
+      - node-knex
       - node-koa
       - node-memcached
       - node-mongodb-core
@@ -591,6 +592,7 @@ workflows:
       - node-graphql
       - node-hapi
       - node-http
+      - node-knex
       - node-koa
       - node-memcached
       - node-mongodb-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,13 @@ jobs:
         environment:
           - PLUGINS=koa
 
+  node-knex:
+    <<: *node-plugin-base
+    docker:
+      - image: node:8
+        environment:
+          - PLUGINS=knex
+  
   node-memcached:
     <<: *node-plugin-base
     docker:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For detailed information about configuration and usage, please see the [API docu
 * [http/https](https://nodejs.org/api/http.html) - `use('http')`, `use('https')`
 * [ioredis 2+](https://github.com/luin/ioredis) - `use('ioredis')`
 * [Koa 2+](https://koajs.com/) - `use('koa')`
+* [Knex 0.10+](https://knexjs.org/) - `use('bluebird'); use('knex')` (depends on bluebird instrumentation)
 * [Memcached 2.2+](https://github.com/3rd-Eden/memcached) - `use('memcached')`
 * [MongoDB-Core 2+](https://github.com/mongodb-js/mongodb-core) - `use('mongodb-core')`
 * [mysql 2+](https://github.com/mysqljs/mysql) - `use('mysql')`

--- a/docs/API.md
+++ b/docs/API.md
@@ -604,6 +604,18 @@ query HelloWorld {
 | http.status_code | The HTTP status code of the response.                     |
 | http.headers.*   | A recorded HTTP header.                                   |
 
+#### Knex
+
+##### Tags
+
+| Tag              | Description                                                |
+|------------------|------------------------------------------------------------|
+| component        | `knex`                                                     |
+| db.type          | The database driver being used such as sqlite3, etc        |
+| db.user          | The database user used by the driver to connect to the db. |
+| db.statement     | The SQL statement executed by the traced query.            |
+| db.instance      | The name of the queried database instance.                 |
+
 ##### Configuration Options
 
 | Option           | Default                   | Description                            |

--- a/src/plugins/knex.js
+++ b/src/plugins/knex.js
@@ -1,52 +1,56 @@
 'use strict'
 
-const tx = require('./util/promise')
+const spanSymbol = '_sfxSpan'
+const maxQueryLength = 1024
 
-function createWrapQueryBuilderToSQL (tracer, config) {
-  return function wrapToSQL (toSQL) {
-    return function toSQLWithTrace (method, tz) {
+function createWrapBuilder (tracer, config) {
+  return function wrapQueryBuilder (original) {
+    return function queryBuilderWithTrace () {
       const scope = tracer.scope()
-      const childOf = scope.active()
-      const mthd = method || this._method
-
-      const span = tracer.startSpan(`knex.QueryBuilder.toSQL(${mthd})`, {
-        childOf,
-        tags: {
-          'component': 'knex'
-        }
-      })
-      setDBTags(this, span)
-
-      return scope.activate(span, () => {
-        try {
-          return toSQL.apply(this, arguments)
-        } catch (e) {
-          throw addError(span, e)
-        } finally {
-          span.finish()
-        }
-      })
+      const span = scope.active()
+      const builder = original.apply(this, arguments)
+      return Object.defineProperty(builder, spanSymbol, { value: span })
     }
   }
 }
 
-function createWrapSchemaBuilderToSQL (tracer, config) {
-  return function wrapToSQL (toSQL) {
-    return function toSQLWithTrace () {
+function createWrapRunner (wrapper, tracer, config) {
+  return function wrapRunner (original) {
+    return function runnerWithTrace () {
+      const runner = original.apply(this, arguments)
+      wrapper.wrap(runner, 'query', createWrapRunnerQuery(tracer, config))
+      return runner
+    }
+  }
+}
+
+function createWrapRunnerQuery (tracer, config) {
+  return function wrapQuery (original) {
+    return function queryWithTrace (q) {
       const scope = tracer.scope()
-      const childOf = scope.active()
-      const span = tracer.startSpan('knex.SchemaBuilder.toSQL', {
+      const childOf = this.builder[spanSymbol]
+
+      const tags = {
+        'component': 'knex',
+        'db.statement': q.sql.substr(0, maxQueryLength)
+      }
+      if (q.timeout !== undefined) {
+        tags.timeout = q.timeout
+      }
+
+      let spanName = 'knex.client.runner'
+      if (q.method !== undefined) {
+        spanName = `knex.client.runner.${q.method}`
+      }
+      const span = tracer.startSpan(spanName, {
         childOf,
-        tags: {
-          'component': 'knex'
-        }
+        tags
       })
       setDBTags(this, span)
-      setMethods(this, span)
 
       return scope.activate(span, () => {
         try {
-          return toSQL.apply(this, arguments)
+          return original.apply(this, arguments)
         } catch (e) {
           throw addError(span, e)
         } finally {
@@ -73,58 +77,39 @@ function setDBTags (obj, span) {
     if (config.client) {
       span.setTag('db.type', config.client)
     }
-    if (config.connection && config.connection.user) {
-      span.setTag('db.user', config.connection.user)
+    if (config.connection) {
+      if (config.connection.user) {
+        span.setTag('db.user', config.connection.user)
+      }
+      const instance = config.connection.filename || config.connection.database
+      if (instance) {
+        span.setTag('db.instance', instance)
+      }
     }
   }
 }
 
-function setMethods (obj, span) {
-  if (obj._sequence) {
-    const methods = []
-    for (let i = 0, l = obj._sequence.length; i < l; i++) {
-      methods.push(obj._sequence[i].method)
+function patchKnex (version, basePath) {
+  return [
+    {
+      name: 'knex',
+      versions: version,
+      file: `${basePath}/client.js`,
+      patch (Client, tracer, config) {
+        this.wrap(Client.prototype, 'queryBuilder', createWrapBuilder(tracer, config))
+        this.wrap(Client.prototype, 'schemaBuilder', createWrapBuilder(tracer, config))
+        this.wrap(Client.prototype, 'raw', createWrapBuilder(tracer, config))
+        this.wrap(Client.prototype, 'runner', createWrapRunner(this, tracer, config))
+      },
+      unpatch (Client) {
+        this.unwrap(Client.prototype, 'runner')
+        this.unwrap(Client.prototype, 'raw')
+        this.unwrap(Client.prototype, 'schemaBuilder')
+        this.unwrap(Client.prototype, 'queryBuilder')
+      }
     }
-    span.setTag('schema.methods', methods)
-  }
+  ]
 }
 
-module.exports = [
-  {
-    name: 'knex',
-    versions: ['>=0.8.0'],
-    file: 'lib/query/builder.js',
-    patch (Builder, tracer, config) {
-      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
-      this.wrap(Builder.prototype, 'toSQL', createWrapQueryBuilderToSQL(tracer, config))
-    },
-    unpatch (Builder) {
-      this.unwrap(Builder.prototype, 'then')
-      this.unwrap(Builder.prototype, 'toSQL')
-    }
-  },
-  {
-    name: 'knex',
-    versions: ['>=0.8.0'],
-    file: 'lib/schema/builder.js',
-    patch (Builder, tracer, config) {
-      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
-      this.wrap(Builder.prototype, 'toSQL', createWrapSchemaBuilderToSQL(tracer, config))
-    },
-    unpatch (Builder) {
-      this.unwrap(Builder.prototype, 'then')
-      this.unwrap(Builder.prototype, 'toSQL')
-    }
-  },
-  {
-    name: 'knex',
-    versions: ['>=0.8.0'],
-    file: 'lib/raw.js',
-    patch (Raw, tracer, config) {
-      this.wrap(Raw.prototype, 'then', tx.createWrapThen(tracer, config))
-    },
-    unpatch (Raw) {
-      this.unwrap(Raw.prototype, 'then')
-    }
-  }
-]
+module.exports = patchKnex(['>=0.10.0 <0.18.0', '>=0.19.0 <0.21.0'], 'lib')
+  .concat(patchKnex(['>=0.18.0 <0.19.0'], 'src'))

--- a/src/plugins/knex.js
+++ b/src/plugins/knex.js
@@ -2,22 +2,129 @@
 
 const tx = require('./util/promise')
 
-function createPatch (file) {
-  return {
-    name: 'knex',
-    versions: ['>=0.8.0'],
-    file,
-    patch (Builder, tracer, config) {
-      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
-    },
-    unpatch (Builder) {
-      this.unwrap(Builder.prototype, 'then')
+function createWrapQueryBuilderToSQL (tracer, config) {
+  return function wrapToSQL (toSQL) {
+    return function toSQLWithTrace (method, tz) {
+      const scope = tracer.scope()
+      const childOf = scope.active()
+      const mthd = method || this._method
+
+      const span = tracer.startSpan(`knex.QueryBuilder.toSQL(${mthd})`, {
+        childOf,
+        tags: {
+          'component': 'knex'
+        }
+      })
+      setDBTags(this, span)
+
+      return scope.activate(span, () => {
+        try {
+          return toSQL.apply(this, arguments)
+        } catch (e) {
+          throw addError(span, e)
+        } finally {
+          span.finish()
+        }
+      })
     }
   }
 }
 
+function createWrapSchemaBuilderToSQL (tracer, config) {
+  return function wrapToSQL (toSQL) {
+    return function toSQLWithTrace () {
+      const scope = tracer.scope()
+      const childOf = scope.active()
+      const span = tracer.startSpan('knex.SchemaBuilder.toSQL', {
+        childOf,
+        tags: {
+          'component': 'knex'
+        }
+      })
+      setDBTags(this, span)
+      setMethods(this, span)
+
+      return scope.activate(span, () => {
+        try {
+          return toSQL.apply(this, arguments)
+        } catch (e) {
+          throw addError(span, e)
+        } finally {
+          span.finish()
+        }
+      })
+    }
+  }
+}
+
+function addError (span, error) {
+  span.setTag('error', 'true')
+  span.log({
+    'error.type': error.name,
+    'error.msg': error.message,
+    'error.stack': error.stack
+  })
+  return error
+}
+
+function setDBTags (obj, span) {
+  if (obj.client && obj.client.config) {
+    const config = obj.client.config
+    if (config.client) {
+      span.setTag('db.type', config.client)
+    }
+    if (config.connection && config.connection.user) {
+      span.setTag('db.user', config.connection.user)
+    }
+  }
+}
+
+function setMethods (obj, span) {
+  if (obj._sequence) {
+    const methods = []
+    for (let i = 0, l = obj._sequence.length; i < l; i++) {
+      methods.push(obj._sequence[i].method)
+    }
+    span.setTag('schema.methods', methods)
+  }
+}
+
 module.exports = [
-  createPatch('lib/query/builder.js'),
-  createPatch('lib/raw.js'),
-  createPatch('lib/schema/builder.js')
+  {
+    name: 'knex',
+    versions: ['>=0.8.0'],
+    file: 'lib/query/builder.js',
+    patch (Builder, tracer, config) {
+      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
+      this.wrap(Builder.prototype, 'toSQL', createWrapQueryBuilderToSQL(tracer, config))
+    },
+    unpatch (Builder) {
+      this.unwrap(Builder.prototype, 'then')
+      this.unwrap(Builder.prototype, 'toSQL')
+    }
+  },
+  {
+    name: 'knex',
+    versions: ['>=0.8.0'],
+    file: 'lib/schema/builder.js',
+    patch (Builder, tracer, config) {
+      this.wrap(Builder.prototype, 'then', tx.createWrapThen(tracer, config))
+      this.wrap(Builder.prototype, 'toSQL', createWrapSchemaBuilderToSQL(tracer, config))
+    },
+    unpatch (Builder) {
+      this.unwrap(Builder.prototype, 'then')
+      this.unwrap(Builder.prototype, 'toSQL')
+    }
+  },
+  {
+    name: 'knex',
+    versions: ['>=0.8.0'],
+    file: 'lib/raw.js',
+    patch (Raw, tracer, config) {
+      this.wrap(Raw.prototype, 'then', tx.createWrapThen(tracer, config))
+    },
+    unpatch (Raw) {
+      this.unwrap(Raw.prototype, 'then')
+    }
+  }
 ]

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -8,6 +8,7 @@ const path = require('path')
 const Int64BE = require('int64-buffer').Int64BE
 
 const handlers = new Set()
+let receivedRequests = []
 let agent = null
 let server = null
 let listener = null
@@ -53,6 +54,7 @@ module.exports = {
     })
 
     agent.post('/v1/trace', (req, res) => {
+      receivedRequests.push(req.body)
       res.status(200).send()
       handlers.forEach(handler => handler(req.body))
     })
@@ -129,6 +131,7 @@ module.exports = {
 
   // Unregister any outstanding expectation callbacks.
   reset () {
+    receivedRequests = []
     handlers.clear()
   },
 
@@ -143,6 +146,10 @@ module.exports = {
   // Return the current active span.
   currentSpan () {
     return tracer.scope().active()
+  },
+
+  receivedRequests () {
+    return receivedRequests
   },
 
   // Stop the mock agent, reset all expectations and wipe the require cache.

--- a/test/plugins/knex.spec.js
+++ b/test/plugins/knex.spec.js
@@ -5,6 +5,12 @@
 const agent = require('./agent')
 const plugin = require('../../src/plugins/knex')
 
+const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
+
+function normalizeDBStatement (statement) {
+  return statement.replace(/"/g, '`')
+}
+
 wrapIt()
 
 describe('Plugin', () => {
@@ -13,39 +19,37 @@ describe('Plugin', () => {
   let tracer
 
   describe('knex', () => {
+    beforeEach(() => {
+      // older versions of knex depend on bluebird
+      return agent.load(plugin, ['knex', 'bluebird'])
+    })
+    afterEach(() => {
+      return agent.reset()
+    })
     withVersions(plugin, 'knex', version => {
-      beforeEach(() => {
-        tracer = require('../..')
-      })
-
-      after(() => {
-        return agent.close()
-      })
-
       describe('without configuration', () => {
         beforeEach(() => {
-          return agent.load(plugin, ['knex'])
-            .then(() => {
-              knex = require(`../../versions/knex@${version}`).get()
-              client = knex({
-                client: 'sqlite3',
-                connection: {
-                  filename: ':memory:'
-                },
-                useNullAsDefault: true
-              })
-            })
-      })
+          tracer = require('../..')
+          knex = require(`../../versions/knex@${version}`).get()
+          client = knex({
+            client: 'sqlite3',
+            connection: {
+              filename: ':memory:'
+            },
+            useNullAsDefault: true
+          })
+        })
 
         afterEach(() => {
           client.schema.dropTableIfExists('testTable')
+          client.schema.dropTableIfExists('testTable1')
+          client.schema.dropTableIfExists('testTable2')
+          client.destroy()
         })
 
         it('should propagate context in the parent context', (done) => {
           if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
-
           const span = {}
-
           tracer.scope().activate(span, () => {
             client.raw('PRAGMA user_version')
               .then(() => {
@@ -55,68 +59,170 @@ describe('Plugin', () => {
           })
         })
 
+        it('should propagate separate context to concurrent queries', (done) => {
+          setTimeout(() => {
+            done(new Error('timed out while waiting for concurrent traces to arrive'))
+          }, 3000)
+
+          function testTraces (traces, test) {
+            expect(traces).to.have.length(1)
+
+            const trace = traces[0]
+            expect(trace).to.have.length(4)
+            const spans = sort(trace)
+
+            expect(spans[0]).to.have.property('service', 'test')
+            expect(spans[0]).to.have.property('name', test.name)
+            expect(spans[0]).to.not.have.property('parent_id')
+
+            expect(spans[1]).to.have.property('name', 'knex.client.runner')
+            expect(normalizeDBStatement(spans[1].meta['db.statement'])).to.be.equal(test.createQuery)
+            expect(spans[1].parent_id.toString()).to.equal(spans[0].span_id.toString())
+
+            expect(spans[2]).to.have.property('name', 'knex.client.runner.insert')
+            expect(normalizeDBStatement(spans[2].meta['db.statement'])).to.be.equal(test.insertQuery)
+            expect(spans[2].parent_id.toString()).to.equal(spans[0].span_id.toString())
+
+            expect(spans[3]).to.have.property('name', 'knex.client.runner.select')
+            expect(normalizeDBStatement(spans[3].meta['db.statement'])).to.be.equal(test.selectQuery)
+            expect(spans[3].parent_id.toString()).to.equal(spans[0].span_id.toString())
+          }
+
+          function testRequests () {
+            const receivedRequests = agent.receivedRequests()
+            testTraces(receivedRequests[0], {
+              name: 'testOpA',
+              title: 'test1',
+              createQuery: 'create table `testTable1` (`title` varchar(255))',
+              insertQuery: 'insert into `testTable1` (`title`) values (?)',
+              selectQuery: 'select * from `testTable1`'
+            })
+
+            testTraces(receivedRequests[1], {
+              name: 'testOpB',
+              title: 'test2',
+              createQuery: 'create table `testTable2` (`title` varchar(255))',
+              insertQuery: 'insert into `testTable2` (`title`) values (?)',
+              selectQuery: 'select * from `testTable2`'
+            })
+            done()
+          }
+
+          // insert timeouts to increase chances of the two ops running concurrently
+          const spanA = tracer.startSpan('testOpA')
+          tracer.scope().activate(spanA, () => {
+            client.schema
+              .createTable('testTable1', (table) => {
+                table.string('title')
+              })
+              .then(setTimeout(() => {
+                client.insert({ title: 'test1' }).into('testTable1')
+                  .then(setTimeout(() => {
+                    client('testTable1').select('*')
+                      .then(() => {
+                        spanA.finish()
+                        setTimeout(testRequests, 30)
+                      })
+                  }), 50)
+              }), 50)
+          })
+
+          const spanB = tracer.startSpan('testOpB')
+          tracer.scope().activate(spanB, () => {
+            client.schema
+              .createTable('testTable2', (table) => {
+                table.string('title')
+              })
+              .then(() => {
+                client.insert({ title: 'test2' }).into('testTable2')
+                  .then(() => {
+                    return client('testTable2').select('*')
+                      .then(() => {
+                        spanB.finish()
+                      })
+                  })
+              })
+          })
+        })
+
         it('should automatically instrument schema builds', done => {
           agent.use(traces => {
-            expect(traces[0][0]).to.have.property('service', 'test')
-            expect(traces[0][0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
-            expect(traces[0][0].meta).to.have.property('component', 'knex')
-            expect(traces[0][0].meta).to.have.property('schema.methods', 'createTable')
-            expect(traces[0][0].meta).to.have.property('db.type', 'sqlite3')
-
+            const spans = sort(traces[0])
+            expect(spans[0]).to.have.property('service', 'test')
+            expect(spans[0]).to.have.property('name', 'knex.client.runner')
+            expect(spans[0].meta).to.have.property('component', 'knex')
+            expect(spans[0].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[0].meta).to.have.property('db.statement')
+            expect(spans[0].meta).to.have.property('db.instance', ':memory:')
+            expect(normalizeDBStatement(spans[0].meta['db.statement'])).to.be.equal(
+              'create table `testTable` (`id` integer, `title` varchar(255))'
+            )
             done()
           })
-          .catch(done)
+            .catch(done)
 
           client.schema.createTable('testTable', (table) => {
             table.integer('id')
             table.string('title')
           }).then(() => {})
-      })
+        })
 
         it('should automatically instrument simple queries', done => {
           agent.use(traces => {
-
-            const spans = traces[0]
-
+            const spans = sort(traces[0])
             expect(spans).to.have.length(4)
+            const rootSpan = spans[0]
 
             expect(spans[0]).to.have.property('service', 'test')
-            expect(spans[0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
-            expect(spans[0].meta).to.have.property('component', 'knex')
-            expect(spans[0].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[0].meta).to.have.property('schema.methods', 'createTable')
-            expect(spans[0].parent_id.toString()).to.equal(spans[3].span_id.toString())
+            expect(spans[0]).to.have.property('name', 'testSpan')
 
             expect(spans[1]).to.have.property('service', 'test')
-            expect(spans[1]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[1]).to.have.property('name', 'knex.client.runner')
             expect(spans[1].meta).to.have.property('component', 'knex')
             expect(spans[1].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[1].parent_id.toString()).to.equal(spans[3].span_id.toString())
+            expect(spans[1].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[1].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[1].meta['db.statement'])).to.be.equal(
+              'create table `testTable` (`id` integer, `title` varchar(255))'
+            )
+            expect(spans[1].parent_id.toString()).to.equal(rootSpan.span_id.toString())
 
             expect(spans[2]).to.have.property('service', 'test')
-            expect(spans[2]).to.have.property('name', 'knex.QueryBuilder.toSQL(select)')
+            expect(spans[2]).to.have.property('name', 'knex.client.runner.insert')
             expect(spans[2].meta).to.have.property('component', 'knex')
             expect(spans[2].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[2].parent_id.toString()).to.equal(spans[3].span_id.toString())
+            expect(spans[2].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[2].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[2].meta['db.statement'])).to.be.equal(
+              'insert into `testTable` (`id`, `title`) values (?, ?)'
+            )
+            expect(spans[2].parent_id.toString()).to.equal(rootSpan.span_id.toString())
 
             expect(spans[3]).to.have.property('service', 'test')
-            expect(spans[3]).to.have.property('name', 'testSpan')
+            expect(spans[3]).to.have.property('name', 'knex.client.runner.select')
+            expect(spans[3].meta).to.have.property('component', 'knex')
+            expect(spans[3].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[3].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[3].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[3].meta['db.statement'])).to.be.equal('select * from `testTable`')
+            expect(spans[3].parent_id.toString()).to.equal(rootSpan.span_id.toString())
+
             done()
           })
-          .catch(done)
+            .catch(done)
 
           const span = tracer.startSpan('testSpan')
 
           tracer.scope().activate(span, () => {
             client.schema
-            .createTable('testTable', (table) => {
-              table.integer('id')
-              table.string('title')
-            })
-            .then(() => {
-              return client.insert({id: 1, title: 'knex test'}).into('testTable');
-            })
-            .then(() => {
+              .createTable('testTable', (table) => {
+                table.integer('id')
+                table.string('title')
+              })
+              .then(() => {
+                return client.insert({ id: 1, title: 'knex test' }).into('testTable')
+              })
+              .then(() => {
                 return client('testTable').select('*')
                   .then(() => {
                     span.finish()
@@ -126,70 +232,174 @@ describe('Plugin', () => {
         })
 
         it('should automatically instrument complex queries', done => {
-          agent.use(traces => {
-            const spans = traces[0]
+          const span = tracer.startSpan('testSpan')
 
-            expect(spans).to.have.length(5)
+          agent.use(traces => {
+            const spans = sort(traces[0])
+            expect(spans).to.have.length(6)
+            const rootSpan = spans[0]
 
             expect(spans[0]).to.have.property('service', 'test')
-            expect(spans[0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
-            expect(spans[0].meta).to.have.property('component', 'knex')
-            expect(spans[0].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[0].meta).to.have.property('schema.methods', 'createTable,createTable')
-            expect(spans[0].parent_id.toString()).to.equal(spans[4].span_id.toString())
+            expect(spans[0]).to.have.property('name', 'testSpan')
 
             expect(spans[1]).to.have.property('service', 'test')
-            expect(spans[1]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[1]).to.have.property('name', 'knex.client.runner')
             expect(spans[1].meta).to.have.property('component', 'knex')
             expect(spans[1].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[1].parent_id.toString()).to.equal(spans[4].span_id.toString())
+            expect(spans[1].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[1].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[1].meta['db.statement'])).to.be.equal(
+              'create table `users` (`id` integer not null primary key autoincrement, `user_name` varchar(255))'
+            )
+            expect(spans[1].trace_id.toString()).to.equal((rootSpan.span_id.toString()))
 
             expect(spans[2]).to.have.property('service', 'test')
-            expect(spans[2]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[2]).to.have.property('name', 'knex.client.runner')
             expect(spans[2].meta).to.have.property('component', 'knex')
             expect(spans[2].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[2].parent_id.toString()).to.equal(spans[4].span_id.toString())
+            expect(spans[2].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[2].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[2].meta['db.statement'])).to.be.equal(
+              'create table `accounts` (`id` integer not null primary key autoincrement,' +
+              ' `account_name` varchar(255), `user_id` integer, foreign key(`user_id`) ' +
+              'references `users`(`id`))')
+            expect(spans[2].trace_id.toString()).to.equal((rootSpan.span_id.toString()))
 
             expect(spans[3]).to.have.property('service', 'test')
-            expect(spans[3]).to.have.property('name', 'knex.QueryBuilder.toSQL(select)')
+            expect(spans[3]).to.have.property('name', 'knex.client.runner.insert')
             expect(spans[3].meta).to.have.property('component', 'knex')
             expect(spans[3].meta).to.have.property('db.type', 'sqlite3')
-            expect(spans[3].parent_id.toString()).to.equal(spans[4].span_id.toString())
+            expect(spans[3].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[3].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[3].meta['db.statement'])).to.be.equal(
+              'insert into `users` (`user_name`) values (?)'
+            )
+            expect(spans[3].trace_id.toString()).to.equal((rootSpan.span_id.toString()))
 
             expect(spans[4]).to.have.property('service', 'test')
-            expect(spans[4]).to.have.property('name', 'testSpan')
+            expect(spans[4]).to.have.property('name', 'knex.client.runner.insert')
+            expect(spans[4].meta).to.have.property('component', 'knex')
+            expect(spans[4].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[4].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[4].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[4].meta['db.statement'])).to.be.equal(
+              'insert into `accounts` (`account_name`, `user_id`) values (?, ?)'
+            )
+            expect(spans[4].trace_id.toString()).to.equal((rootSpan.span_id.toString()))
+
+            expect(spans[5]).to.have.property('service', 'test')
+            expect(spans[5]).to.have.property('name', 'knex.client.runner.select')
+            expect(spans[5].meta).to.have.property('component', 'knex')
+            expect(spans[5].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[5].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[5].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[5].meta['db.statement'])).to.be.equal(
+              'select `users`.`user_name` as `user`, `accounts`.`account_name` as `account`' +
+              ' from `users` inner join `accounts` on `users`.`id` = `accounts`.`user_id`'
+            )
+            expect(spans[5].trace_id.toString()).to.equal((rootSpan.span_id.toString()))
 
             done()
           })
-        .catch(done)
+            .catch(done)
 
-          const span = tracer.startSpan('testSpan')
           tracer.scope().activate(span, () => {
             client.schema
-              .createTable('users', function(table) {
-                table.increments('id');
-                table.string('user_name');
+              .createTable('users', function (table) {
+                table.increments('id')
+                table.string('user_name')
               })
-              .createTable('accounts', function(table) {
-                table.increments('id');
-                table.string('account_name');
-                table.integer('user_id').unsigned().references('users.id');
+              .createTable('accounts', function (table) {
+                table.increments('id')
+                table.string('account_name')
+                table.integer('user_id').unsigned().references('users.id')
               })
-              .then(function() {
-                return client.insert({user_name: 'Tim'}).into('users');
+              .then(function () {
+                return client.insert({ user_name: 'Tim' }).into('users')
               })
-              .then(function(rows) {
-                return client.table('accounts').insert({account_name: 'knex', user_id: rows[0]});
+              .then(function (rows) {
+                return client.table('accounts').insert({ account_name: 'knex', user_id: rows[0] })
               })
-              .then(function() {
+              .then(function () {
                 return client('users')
                   .join('accounts', 'users.id', 'accounts.user_id')
                   .select('users.user_name as user', 'accounts.account_name as account')
-                  .then (() => {
+                  .then(() => {
                     span.finish()
                   })
-               })
-            })
+              })
+          })
+        })
+        it('should work with nested custom spans', done => {
+          agent.use(traces => {
+            const spans = sort(traces[0])
+            expect(spans).to.have.length(5)
+            const rootSpan = spans[0]
+
+            expect(spans[0]).to.have.property('service', 'test')
+            expect(spans[0]).to.have.property('name', 'outerSpan')
+
+            expect(spans[1]).to.have.property('service', 'test')
+            expect(spans[1]).to.have.property('name', 'knex.client.runner')
+            expect(spans[1].meta).to.have.property('component', 'knex')
+            expect(spans[1].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[1].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[1].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[1].meta['db.statement'])).to.be.equal(
+              'create table `testTable` (`id` integer, `title` varchar(255))'
+            )
+            expect(spans[1].parent_id.toString()).to.equal(rootSpan.span_id.toString())
+
+            expect(spans[2]).to.have.property('service', 'test')
+            expect(spans[2]).to.have.property('name', 'innerSpan')
+            const innerSpan = spans[2]
+
+            expect(spans[3]).to.have.property('service', 'test')
+            expect(spans[3]).to.have.property('name', 'knex.client.runner.insert')
+            expect(spans[3].meta).to.have.property('component', 'knex')
+            expect(spans[3].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[3].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[3].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[3].meta['db.statement'])).to.be.equal(
+              'insert into `testTable` (`id`, `title`) values (?, ?)'
+            )
+            expect(spans[3].parent_id.toString()).to.equal(innerSpan.span_id.toString())
+
+            expect(spans[4]).to.have.property('service', 'test')
+            expect(spans[4]).to.have.property('name', 'knex.client.runner.select')
+            expect(spans[4].meta).to.have.property('component', 'knex')
+            expect(spans[4].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[4].meta).to.have.property('db.instance', ':memory:')
+            expect(spans[4].meta).to.have.property('db.statement')
+            expect(normalizeDBStatement(spans[4].meta['db.statement'])).to.be.equal('select * from `testTable`')
+            expect(spans[4].parent_id.toString()).to.equal(innerSpan.span_id.toString())
+
+            done()
+          })
+            .catch(done)
+
+          const outerSpan = tracer.startSpan('outerSpan')
+
+          tracer.scope().activate(outerSpan, () => {
+            client.schema
+              .createTable('testTable', (table) => {
+                table.integer('id')
+                table.string('title')
+              })
+              .then(() => {
+                const innerSpan = tracer.startSpan('innerSpan', { childOf: outerSpan })
+                tracer.scope().activate(innerSpan, () => {
+                  return client.insert({ id: 1, title: 'knex test' }).into('testTable')
+                    .then(() => {
+                      return client('testTable').select('*')
+                        .then(() => {
+                          innerSpan.finish()
+                          outerSpan.finish()
+                        })
+                    })
+                })
+              })
+          })
         })
 
         it('should propagate context to callbacks', done => {
@@ -198,14 +408,12 @@ describe('Plugin', () => {
           const span = tracer.startSpan('test')
 
           tracer.scope().activate(span, () => {
-            const span = tracer.scope().active()
             client.schema.createTable('testTable', (table) => {
               table.integer('id')
               table.string('title')
             })
-            .asCallback((err) => {
+              .asCallback((err) => {
                 if (err) throw err
-
                 expect(tracer.scope().active()).to.equal(span)
                 span.finish()
                 done()

--- a/test/plugins/knex.spec.js
+++ b/test/plugins/knex.spec.js
@@ -18,7 +18,7 @@ describe('Plugin', () => {
         tracer = require('../..')
       })
 
-      afterEach(() => {
+      after(() => {
         return agent.close()
       })
 
@@ -31,19 +31,184 @@ describe('Plugin', () => {
                 client: 'sqlite3',
                 connection: {
                   filename: ':memory:'
-                }
+                },
+                useNullAsDefault: true
               })
             })
+      })
+
+        afterEach(() => {
+          client.schema.dropTableIfExists('testTable')
         })
-        it('should propagate context', () => {
-          if (process.env.DD_CONTEXT_PROPAGATION === 'false') return
+
+        it('should propagate context in the parent context', (done) => {
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return
 
           const span = {}
 
-          return tracer.scope().activate(span, () => {
-            return client.raw('PRAGMA user_version')
+          tracer.scope().activate(span, () => {
+            client.raw('PRAGMA user_version')
               .then(() => {
                 expect(tracer.scope().active()).to.equal(span)
+                done()
+              })
+          })
+        })
+
+        it('should automatically instrument schema builds', done => {
+          agent.use(traces => {
+            expect(traces[0][0]).to.have.property('service', 'test')
+            expect(traces[0][0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
+            expect(traces[0][0].meta).to.have.property('component', 'knex')
+            expect(traces[0][0].meta).to.have.property('schema.methods', 'createTable')
+            expect(traces[0][0].meta).to.have.property('db.type', 'sqlite3')
+
+            done()
+          })
+          .catch(done)
+
+          client.schema.createTable('testTable', (table) => {
+            table.integer('id')
+            table.string('title')
+          }).then(() => {})
+      })
+
+        it('should automatically instrument simple queries', done => {
+          agent.use(traces => {
+
+            const spans = traces[0]
+
+            expect(spans).to.have.length(4)
+
+            expect(spans[0]).to.have.property('service', 'test')
+            expect(spans[0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
+            expect(spans[0].meta).to.have.property('component', 'knex')
+            expect(spans[0].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[0].meta).to.have.property('schema.methods', 'createTable')
+            expect(spans[0].parent_id.toString()).to.equal(spans[3].span_id.toString())
+
+            expect(spans[1]).to.have.property('service', 'test')
+            expect(spans[1]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[1].meta).to.have.property('component', 'knex')
+            expect(spans[1].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[1].parent_id.toString()).to.equal(spans[3].span_id.toString())
+
+            expect(spans[2]).to.have.property('service', 'test')
+            expect(spans[2]).to.have.property('name', 'knex.QueryBuilder.toSQL(select)')
+            expect(spans[2].meta).to.have.property('component', 'knex')
+            expect(spans[2].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[2].parent_id.toString()).to.equal(spans[3].span_id.toString())
+
+            expect(spans[3]).to.have.property('service', 'test')
+            expect(spans[3]).to.have.property('name', 'testSpan')
+            done()
+          })
+          .catch(done)
+
+          const span = tracer.startSpan('testSpan')
+
+          tracer.scope().activate(span, () => {
+            client.schema
+            .createTable('testTable', (table) => {
+              table.integer('id')
+              table.string('title')
+            })
+            .then(() => {
+              return client.insert({id: 1, title: 'knex test'}).into('testTable');
+            })
+            .then(() => {
+                return client('testTable').select('*')
+                  .then(() => {
+                    span.finish()
+                  })
+              })
+          })
+        })
+
+        it('should automatically instrument complex queries', done => {
+          agent.use(traces => {
+            const spans = traces[0]
+
+            expect(spans).to.have.length(5)
+
+            expect(spans[0]).to.have.property('service', 'test')
+            expect(spans[0]).to.have.property('name', 'knex.SchemaBuilder.toSQL')
+            expect(spans[0].meta).to.have.property('component', 'knex')
+            expect(spans[0].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[0].meta).to.have.property('schema.methods', 'createTable,createTable')
+            expect(spans[0].parent_id.toString()).to.equal(spans[4].span_id.toString())
+
+            expect(spans[1]).to.have.property('service', 'test')
+            expect(spans[1]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[1].meta).to.have.property('component', 'knex')
+            expect(spans[1].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[1].parent_id.toString()).to.equal(spans[4].span_id.toString())
+
+            expect(spans[2]).to.have.property('service', 'test')
+            expect(spans[2]).to.have.property('name', 'knex.QueryBuilder.toSQL(insert)')
+            expect(spans[2].meta).to.have.property('component', 'knex')
+            expect(spans[2].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[2].parent_id.toString()).to.equal(spans[4].span_id.toString())
+
+            expect(spans[3]).to.have.property('service', 'test')
+            expect(spans[3]).to.have.property('name', 'knex.QueryBuilder.toSQL(select)')
+            expect(spans[3].meta).to.have.property('component', 'knex')
+            expect(spans[3].meta).to.have.property('db.type', 'sqlite3')
+            expect(spans[3].parent_id.toString()).to.equal(spans[4].span_id.toString())
+
+            expect(spans[4]).to.have.property('service', 'test')
+            expect(spans[4]).to.have.property('name', 'testSpan')
+
+            done()
+          })
+        .catch(done)
+
+          const span = tracer.startSpan('testSpan')
+          tracer.scope().activate(span, () => {
+            client.schema
+              .createTable('users', function(table) {
+                table.increments('id');
+                table.string('user_name');
+              })
+              .createTable('accounts', function(table) {
+                table.increments('id');
+                table.string('account_name');
+                table.integer('user_id').unsigned().references('users.id');
+              })
+              .then(function() {
+                return client.insert({user_name: 'Tim'}).into('users');
+              })
+              .then(function(rows) {
+                return client.table('accounts').insert({account_name: 'knex', user_id: rows[0]});
+              })
+              .then(function() {
+                return client('users')
+                  .join('accounts', 'users.id', 'accounts.user_id')
+                  .select('users.user_name as user', 'accounts.account_name as account')
+                  .then (() => {
+                    span.finish()
+                  })
+               })
+            })
+        })
+
+        it('should propagate context to callbacks', done => {
+          if (process.env.SIGNALFX_CONTEXT_PROPAGATION === 'false') return done()
+
+          const span = tracer.startSpan('test')
+
+          tracer.scope().activate(span, () => {
+            const span = tracer.scope().active()
+            client.schema.createTable('testTable', (table) => {
+              table.integer('id')
+              table.string('title')
+            })
+            .asCallback((err) => {
+                if (err) throw err
+
+                expect(tracer.scope().active()).to.equal(span)
+                span.finish()
+                done()
               })
           })
         })


### PR DESCRIPTION
This builds on top of: https://github.com/signalfx/signalfx-nodejs-tracing/pull/45

- Added support for both nested and flat promises when using knex.
- Added support for 0.18 series
- Re-worked context propagation to make auto-instrumentation work with all version >0.10
- Added test cases to cover edge cases I discovered or suspected would happen with the new context prop.