### PR TITLE
Support grahpql v15.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,10 +253,17 @@ jobs:
         environment:
           - PLUGINS=generic-pool
 
-  node-graphql:
+  node-8-graphql:
     <<: *node-plugin-base
     docker:
       - image: node:8
+        environment:
+          - PLUGINS=graphql
+
+  node-graphql:
+    <<: *node-plugin-base
+    docker:
+      - image: node:10
         environment:
           - PLUGINS=graphql
 
@@ -539,6 +546,7 @@ workflows:
       - node-elasticsearch
       - node-express
       - node-generic-pool
+      - node-8-graphql
       - node-graphql
       - node-hapi
       - node-http

--- a/src/plugins/graphql.js
+++ b/src/plugins/graphql.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const pick = require('lodash.pick')
+const semver = require('semver')
 const platform = require('../platform')
 const log = require('../log')
 const analyticsSampler = require('../analytics_sampler')
@@ -484,11 +485,15 @@ function pathToArray (path) {
   return flattened.reverse()
 }
 
+const versions = semver.intersects('<10', process.version)
+  ? ['>=0.10 <15']
+  : ['>=0.10']
+
 module.exports = [
   {
     name: 'graphql',
     file: 'execution/execute.js',
-    versions: ['>=0.10'],
+    versions: versions,
     patch (execute, tracer, config) {
       this.wrap(execute, 'execute', createWrapExecute(
         tracer,
@@ -503,7 +508,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'language/parser.js',
-    versions: ['>=0.10'],
+    versions: versions,
     patch (parser, tracer, config) {
       this.wrap(parser, 'parse', createWrapParse(tracer, validateConfig(config)))
     },
@@ -514,7 +519,7 @@ module.exports = [
   {
     name: 'graphql',
     file: 'validation/validate.js',
-    versions: ['>=0.10'],
+    versions: versions,
     patch (validate, tracer, config) {
       this.wrap(validate, 'validate', createWrapValidate(tracer, validateConfig(config)))
     },


### PR DESCRIPTION
GraphQL v15 dropped support for node 8. This commit registers GraphQL v15
and newer only on node>=10. This allows us to run GraphQL tests for both
node 8 and node 10.