### PR TITLE
Use byte length instead of string length to calcular Content-Length

### DIFF
--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -42,20 +42,16 @@ function request (options, callback) {
 }
 
 function byteLength (data) {
-  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
-  /*
   if (data.length === 0) {
     return 0
   }
 
   return data.reduce((prev, next) => {
-
     if (Buffer.isBuffer(next)) {
       return prev + next.length
     }
     return prev + Buffer.byteLength(next, 'utf8')
   }, 0)
-  */
 }
 
 module.exports = request

--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -42,16 +42,20 @@ function request (options, callback) {
 }
 
 function byteLength (data) {
+  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+  /*
   if (data.length === 0) {
     return 0
   }
 
   return data.reduce((prev, next) => {
+
     if (Buffer.isBuffer(next)) {
       return prev + next.length
     }
     return prev + Buffer.byteLength(next, 'utf8')
   }, 0)
+  */
 }
 
 module.exports = request

--- a/src/platform/node/request.js
+++ b/src/platform/node/request.js
@@ -42,7 +42,16 @@ function request (options, callback) {
 }
 
 function byteLength (data) {
-  return data.length > 0 ? data.reduce((prev, next) => prev + next.length, 0) : 0
+  if (data.length === 0) {
+    return 0
+  }
+
+  return data.reduce((prev, next) => {
+    if (Buffer.isBuffer(next)) {
+      return prev + next.length
+    }
+    return prev + Buffer.byteLength(next, 'utf8')
+  }, 0)
 }
 
 module.exports = request

--- a/test/platform/node/index.spec.js
+++ b/test/platform/node/index.spec.js
@@ -261,6 +261,31 @@ describe('Platform', () => {
         })
       })
 
+      it('should send an http request with correct content-length for unicode chars', () => {
+        nock('http://test:333', {
+          reqheaders: {
+            'content-type': 'application/octet-stream',
+            'content-length': '2'
+          }
+        })
+          .put('/unicode')
+          .reply(200, 'OK')
+
+        return request({
+          protocol: 'http:',
+          hostname: 'test',
+          port: 333,
+          path: '/unicode',
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/octet-stream'
+          },
+          data: ['æ']
+        }).then(res => {
+          expect(res).to.equal('OK')
+        })
+      })
+
       it('should handle an http error', done => {
         nock('http://localhost:80')
           .put('/path')


### PR DESCRIPTION
We were calculating string length instead of actual byte length. Some unicode string characters can be larger than a single single byte but would've been counted as a single byte.