### PR TITLE
Introduce SIGNALFX_SPAN_TAGS env var for global tags

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -822,6 +822,7 @@ Options can be configured as a parameter to the `init()` method or as environmen
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+|               | SIGNALFX_SPAN_TAGS           |           | Global tags for all spans (like config `tags`) in format `key1:val1,key2:val2`. |
 
 #### Custom Logging
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -817,12 +817,11 @@ Options can be configured as a parameter to the `init()` method or as environmen
 | enabled       | SIGNALFX_TRACING_ENABLED     | true      | Whether to enable the tracer. |
 | debug         | SIGNALFX_TRACING_DEBUG       | false     | Enable debug logging in the tracer. |
 | logInjection  | SIGNALFX_LOGS_INJECTION      | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags          |                              | {}        | Set global tags that should be applied to all spans. |
+| tags          | SIGNALFX_SPAN_TAGS           | {}        | Set global tags that should be applied to all spans. Format for the environment variable is `key1:val1,key2:val2`.|
 | sampleRate    |                              | 1         | Percentage of spans to sample as a float between 0 and 1. |
 | flushInterval |                              | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | experimental  |                              | {}        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. There are currently no experimental features available. |
 | plugins       |                              | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
-|               | SIGNALFX_SPAN_TAGS           |           | Global tags for all spans (like config `tags`) in format `key1:val1,key2:val2`. |
 
 #### Custom Logging
 

--- a/src/config.js
+++ b/src/config.js
@@ -63,6 +63,14 @@ class Config {
       'signalfx.tracing.library': 'nodejs-tracing',
       'signalfx.tracing.version': version
     }, options.tags)
+    if (process.env.SIGNALFX_SPAN_TAGS) {
+      for (const segment of process.env.SIGNALFX_SPAN_TAGS.split(',')) {
+        const kv = segment.split(':')
+        if (kv.length === 2 && kv[0].trim().length !== 0 && kv[1].trim().length !== 0) {
+          this.tags[kv[0].trim()] = kv[1].trim()
+        }
+      }
+    }
     this.dogstatsd = {
       port: String(coalesce(dogstatsd.port, platform.env('DD_DOGSTATSD_PORT'), 8125))
     }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -25,6 +25,22 @@ class SignalFxTracer extends Tracer {
 
     this._scopeManager = new ScopeManager()
     this._scope = new Scope()
+
+    this._extraTags = {}
+    if (process.env.SIGNALFX_SPAN_TAGS) {
+      for (const segment of process.env.SIGNALFX_SPAN_TAGS.split(',')) {
+        const kv = segment.split(':')
+        if (kv.length === 2 && kv[0].length !== 0 && kv[1].length !== 0) {
+          this._extraTags[kv[0]] = kv[1]
+        }
+      }
+    }
+  }
+
+  startSpan (name, options) {
+    const span = super.startSpan(name, options)
+    span.addTags(this._extraTags)
+    return span
   }
 
   trace (name, options, fn) {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -30,8 +30,8 @@ class SignalFxTracer extends Tracer {
     if (process.env.SIGNALFX_SPAN_TAGS) {
       for (const segment of process.env.SIGNALFX_SPAN_TAGS.split(',')) {
         const kv = segment.split(':')
-        if (kv.length === 2 && kv[0].length !== 0 && kv[1].length !== 0) {
-          this._extraTags[kv[0]] = kv[1]
+        if (kv.length === 2 && kv[0].trim().length !== 0 && kv[1].trim().length !== 0) {
+          this._extraTags[kv[0].trim()] = kv[1].trim()
         }
       }
     }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -25,22 +25,6 @@ class SignalFxTracer extends Tracer {
 
     this._scopeManager = new ScopeManager()
     this._scope = new Scope()
-
-    this._extraTags = {}
-    if (process.env.SIGNALFX_SPAN_TAGS) {
-      for (const segment of process.env.SIGNALFX_SPAN_TAGS.split(',')) {
-        const kv = segment.split(':')
-        if (kv.length === 2 && kv[0].trim().length !== 0 && kv[1].trim().length !== 0) {
-          this._extraTags[kv[0].trim()] = kv[1].trim()
-        }
-      }
-    }
-  }
-
-  startSpan (name, options) {
-    const span = super.startSpan(name, options)
-    span.addTags(this._extraTags)
-    return span
   }
 
   trace (name, options, fn) {

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -115,6 +115,7 @@ describe('Tracer', () => {
 
     it('should accept SIGNALFX_SPAN_TAGS', () => {
       process.env.SIGNALFX_SPAN_TAGS = 'key.1:val1,nocolon,:emptykey,emptyval:,too:many:pieces, key.2 : val2 '
+      config = new Config('test', { service: 'service' })
       tracer = new Tracer(config)
       delete process.env.SIGNALFX_SPAN_TAGS
       const span = tracer.startSpan('name', {})

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -113,6 +113,18 @@ describe('Tracer', () => {
       expect(span.finish).to.have.been.called
     })
 
+    it('should accept SIGNALFX_SPAN_TAGS', () => {
+      process.env.SIGNALFX_SPAN_TAGS = 'key.1:val1,nocolon,:emptykey,emptyval:,too:many:pieces,key.2:val2'
+      tracer = new Tracer(config)
+      delete process.env.SIGNALFX_SPAN_TAGS
+      const span = tracer.startSpan('name', {})
+      span.finish()
+      expect(span.context()._tags).to.include({
+        'key.1': 'val1',
+        'key.2': 'val2'
+      })
+    })
+
     it('should handle exceptions', () => {
       let span
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -114,7 +114,7 @@ describe('Tracer', () => {
     })
 
     it('should accept SIGNALFX_SPAN_TAGS', () => {
-      process.env.SIGNALFX_SPAN_TAGS = 'key.1:val1,nocolon,:emptykey,emptyval:,too:many:pieces,key.2:val2'
+      process.env.SIGNALFX_SPAN_TAGS = 'key.1:val1,nocolon,:emptykey,emptyval:,too:many:pieces, key.2 : val2 '
       tracer = new Tracer(config)
       delete process.env.SIGNALFX_SPAN_TAGS
       const span = tracer.startSpan('name', {})


### PR DESCRIPTION
- Introduce SIGNALFX_SPAN_TAGS with format `key1:val1,key2:val2`
- Add unit test for it
- Add doc line for it
