### PR TITLE
Erase finished spans from memory to reduce memory pressure

### DIFF
--- a/src/opentracing/span.js
+++ b/src/opentracing/span.js
@@ -56,20 +56,13 @@ class SignalFxSpan extends Span {
     let spanContext
 
     if (parent) {
-      const trace = parent._trace
-      const finished = trace.started.length === trace.finished.length
-
       spanContext = new SpanContext({
         traceId: parent._traceId,
         spanId: platform.id(),
         parentId: parent._spanId,
         sampling: parent._sampling,
         baggageItems: parent._baggageItems,
-        trace: {
-          started: finished ? [] : trace.started,
-          finished: finished ? [] : trace.finished,
-          origin: trace.origin
-        }
+        trace: parent._trace
       })
     } else {
       const spanId = platform.id()

--- a/src/scope/new/scope.js
+++ b/src/scope/new/scope.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const asyncHooks = require('../async_hooks')
-const executionAsyncId = asyncHooks.executionAsyncId || asyncHooks.currentId
+const eid = asyncHooks.executionAsyncId || asyncHooks.currentId
 const Base = require('./base')
 const platform = require('../../platform')
 const semver = require('semver')
@@ -32,11 +32,11 @@ class Scope extends Base {
   }
 
   _active () {
-    return this._spans[executionAsyncId()] || null
+    return this._spans[eid()] || null
   }
 
   _activate (span, callback) {
-    const asyncId = executionAsyncId()
+    const asyncId = eid()
     const oldSpan = this._spans[asyncId]
 
     this._spans[asyncId] = span

--- a/src/writer.js
+++ b/src/writer.js
@@ -30,6 +30,7 @@ class Writer {
       this._prioritySampler.sample(spanContext)
 
       const formattedTrace = trace.finished.map(this.format)
+      this._erase(trace)
 
       if (spanContext._sampling.drop === true) {
         log.debug(() => `Dropping trace due to user configured filtering: ${JSON.stringify(formattedTrace)}`)
@@ -95,6 +96,17 @@ class Writer {
         this._prioritySampler.update(JSON.parse(res).rate_by_service)
       })
       .catch(e => log.error(e))
+  }
+
+  _erase (trace) {
+    trace.finished.forEach(span => {
+      span.context()._tags = {}
+      span.context()._logs = []
+      span.context()._metrics = {}
+    })
+
+    trace.started = []
+    trace.finished = []
   }
 }
 

--- a/test/opentracing/span.spec.js
+++ b/test/opentracing/span.spec.js
@@ -75,26 +75,7 @@ describe('Span', () => {
     expect(span.context()._traceId).to.deep.equal(new Uint64BE(123, 123))
     expect(span.context()._parentId).to.deep.equal(new Uint64BE(456, 456))
     expect(span.context()._baggageItems).to.deep.equal({ foo: 'bar' })
-    expect(span.context()._trace.started).to.deep.equal(['span', span])
-    expect(span.context()._trace.origin).to.equal('synthetics')
-  })
-
-  it('should start a new trace if the parent trace is finished', () => {
-    const parent = {
-      _traceId: new Uint64BE(123, 123),
-      _spanId: new Uint64BE(456, 456),
-      _baggageItems: { foo: 'bar' },
-      _trace: {
-        started: ['span'],
-        finished: ['span'],
-        origin: 'synthetics'
-      }
-    }
-
-    span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
-
-    expect(span.context()._trace.started).to.deep.equal([span])
-    expect(span.context()._trace.origin).to.equal('synthetics')
+    expect(span.context()._trace).to.equal(parent._trace)
   })
 
   it('should set the sample rate metric from the sampler', () => {

--- a/test/plugins/util/tx.spec.js
+++ b/test/plugins/util/tx.spec.js
@@ -56,12 +56,13 @@ describe('plugins/util/tx', () => {
         const callback = sinon.spy()
         const error = new Error('boom')
         const wrapper = tx.wrap(span, callback)
+        const tags = span.context()._tags
 
         wrapper(error)
 
-        expect(span.context()._tags).to.have.property('sfx.error.message', error.message)
-        expect(span.context()._tags).to.have.property('sfx.error.kind', error.name)
-        expect(span.context()._tags).to.have.property('sfx.error.stack', error.stack)
+        expect(tags).to.have.property('sfx.error.message', error.message)
+        expect(tags).to.have.property('sfx.error.kind', error.name)
+        expect(tags).to.have.property('sfx.error.stack', error.stack)
       })
 
       it('should return a wrapper that runs in the current scope', done => {
@@ -96,14 +97,15 @@ describe('plugins/util/tx', () => {
       it('should set the error tags when the promise is rejected', () => {
         const error = new Error('boom')
         const promise = Promise.reject(error)
+        const tags = span.context()._tags
 
         tx.wrap(span, promise)
 
         return promise.catch(err => {
           expect(err).to.equal(error)
-          expect(span.context()._tags).to.have.property('sfx.error.message', error.message)
-          expect(span.context()._tags).to.have.property('sfx.error.kind', error.name)
-          expect(span.context()._tags).to.have.property('sfx.error.stack', error.stack)
+          expect(tags).to.have.property('sfx.error.message', error.message)
+          expect(tags).to.have.property('sfx.error.kind', error.name)
+          expect(tags).to.have.property('sfx.error.stack', error.stack)
         })
       })
     })

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -160,9 +160,10 @@ describe('plugins/util/web', () => {
         res.statusCode = '200'
 
         web.instrument(tracer, config, req, res, 'test.request', span => {
+          const tags = span.context()._tags
           res.end()
 
-          expect(span.context()._tags).to.include({
+          expect(tags).to.include({
             [SPAN_TYPE]: HTTP,
             [HTTP_URL]: 'http://localhost/user/123',
             [HTTP_METHOD]: 'GET',
@@ -175,9 +176,10 @@ describe('plugins/util/web', () => {
         config.headers = ['host', 'server']
 
         web.instrument(tracer, config, req, res, 'test.request', span => {
+          const tags = span.context()._tags
           res.end()
 
-          expect(span.context()._tags).to.include({
+          expect(tags).to.include({
             [`${HTTP_REQUEST_HEADERS}.host`]: 'localhost',
             [`${HTTP_RESPONSE_HEADERS}.server`]: 'test'
           })
@@ -226,9 +228,10 @@ describe('plugins/util/web', () => {
 
         web.instrument(tracer, config, req, res, 'test.request', () => {
           web.instrument(tracer, override, req, res, 'test.request', span => {
+            const tags = span.context()._tags
             res.end()
 
-            expect(span.context()._tags).to.include({
+            expect(tags).to.include({
               [`${HTTP_REQUEST_HEADERS}.date`]: 'now'
             })
           })
@@ -241,9 +244,10 @@ describe('plugins/util/web', () => {
         res.statusCode = '200'
 
         web.instrument(tracer, config, req, res, 'test.request', span => {
+          const tags = span.context()._tags
           res.end()
 
-          expect(span.context()._tags).to.include({
+          expect(tags).to.include({
             [HTTP_URL]: 'http://localhost/user/123'
           })
         })
@@ -310,9 +314,10 @@ describe('plugins/util/web', () => {
         req.url = '/user/123'
         res.statusCode = '200'
 
+        const tags = span.context()._tags
         res.end()
 
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           [RESOURCE_NAME]: 'handle.request',
           [HTTP_STATUS_CODE]: '200'
         })
@@ -321,9 +326,10 @@ describe('plugins/util/web', () => {
       it('should set the error tag if the request is an error', () => {
         res.statusCode = 500
 
+        const tags = span.context()._tags
         res.end()
 
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           [ERROR]: true
         })
       })
@@ -331,9 +337,10 @@ describe('plugins/util/web', () => {
       it('should set the error tag if the configured validator returns false', () => {
         config.validateStatus = () => false
 
+        const tags = span.context()._tags
         res.end()
 
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           [ERROR]: true
         })
       })
@@ -341,9 +348,10 @@ describe('plugins/util/web', () => {
       it('should use the user provided route', () => {
         span.setTag('http.route', '/custom/route')
 
+        const tags = span.context()._tags
         res.end()
 
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           [HTTP_ROUTE]: '/custom/route'
         })
       })
@@ -374,9 +382,10 @@ describe('plugins/util/web', () => {
         }
 
         web.instrument(tracer, config, req, res, 'test.request', span => {
+          const tags = span.context()._tags
           res.end()
 
-          expect(span.context()._tags).to.have.property('resource.name', '/custom/route')
+          expect(tags).to.have.property('resource.name', '/custom/route')
         })
       })
     })
@@ -395,10 +404,12 @@ describe('plugins/util/web', () => {
 
       web.enterRoute(req, '/foo')
       web.enterRoute(req, '/bar')
+
+      const tags = span.context()._tags
       res.end()
 
-      expect(span.context()._tags).to.have.property(RESOURCE_NAME, '/foo/bar')
-      expect(span.context()._tags).to.have.property(HTTP_ROUTE, '/foo/bar')
+      expect(tags).to.have.property(RESOURCE_NAME, '/foo/bar')
+      expect(tags).to.have.property(HTTP_ROUTE, '/foo/bar')
     })
   })
 
@@ -416,9 +427,11 @@ describe('plugins/util/web', () => {
       web.enterRoute(req, '/foo')
       web.enterRoute(req, '/bar')
       web.exitRoute(req)
+
+      const tags = span.context()._tags
       res.end()
 
-      expect(span.context()._tags).to.have.property(RESOURCE_NAME, '/foo')
+      expect(tags).to.have.property(RESOURCE_NAME, '/foo')
     })
   })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -115,16 +115,18 @@ describe('Tracer', () => {
 
     it('should handle exceptions', () => {
       let span
+      let tags
 
       try {
         tracer.trace('name', {}, _span => {
           span = _span
+          tags = span.context()._tags
           sinon.spy(span, 'finish')
           throw new Error('boom')
         })
       } catch (e) {
         expect(span.finish).to.have.been.called
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           'sfx.error.kind': e.name,
           'sfx.error.message': e.message,
           'sfx.error.stack': e.stack
@@ -154,9 +156,11 @@ describe('Tracer', () => {
         const error = new Error('boom')
         let span
         let done
+        let tags
 
         tracer.trace('name', {}, (_span, _done) => {
           span = _span
+          tags = span.context()._tags
           sinon.spy(span, 'finish')
           done = _done
         })
@@ -164,7 +168,7 @@ describe('Tracer', () => {
         done(error)
 
         expect(span.finish).to.have.been.called
-        expect(span.context()._tags).to.include({
+        expect(tags).to.include({
           'sfx.error.kind': error.name,
           'sfx.error.message': error.message,
           'sfx.error.stack': error.stack
@@ -200,16 +204,18 @@ describe('Tracer', () => {
 
       it('should handle rejected promises', done => {
         let span
+        let tags
 
         tracer
           .trace('name', {}, _span => {
             span = _span
+            tags = span.context()._tags
             sinon.spy(span, 'finish')
             return Promise.reject(new Error('boom'))
           })
           .catch(e => {
             expect(span.finish).to.have.been.called
-            expect(span.context()._tags).to.include({
+            expect(tags).to.include({
               'sfx.error.kind': e.name,
               'sfx.error.message': e.message,
               'sfx.error.stack': e.stack

--- a/test/writer.spec.js
+++ b/test/writer.spec.js
@@ -18,8 +18,6 @@ describe('Writer', () => {
 
   beforeEach(() => {
     trace = {
-      started: [span],
-      finished: [span]
     }
 
     span = {
@@ -28,6 +26,9 @@ describe('Writer', () => {
         _sampling: {}
       })
     }
+
+    trace.started = [span]
+    trace.finished = [span]
 
     response = JSON.stringify({
       rate_by_service: {
@@ -118,6 +119,18 @@ describe('Writer', () => {
       writer.append(span)
 
       expect(prioritySampler.sample).to.have.been.calledWith(span.context())
+    })
+
+    it('should erase the trace once finished', () => {
+      trace.started = [span]
+      trace.finished = [span]
+
+      writer.append(span)
+
+      expect(trace).to.have.deep.property('started', [])
+      expect(trace).to.have.deep.property('finished', [])
+      expect(span.context()).to.have.deep.property('_tags', {})
+      expect(span.context()).to.have.deep.property('_metrics', {})
     })
   })
 


### PR DESCRIPTION
This should help alleviate effects of memory leaks caused by async scope
leaks.