### PR TITLE
Optionally pass trace context in http response via Server-Timing.

### DIFF
--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -69,7 +69,8 @@ const web = {
     wrapEnd(req)
     wrapEvents(req)
 
-    if (process.env.SIGNALFX_SERVER_TIMING_CONTEXT === 'true') {
+    const enableServerTiming = process.env.SIGNALFX_SERVER_TIMING_CONTEXT
+    if (enableServerTiming && enableServerTiming.trim().toLowerCase() === 'true') {
       res.setHeader('Server-Timing', traceParentHeader(span.context()))
     }
 

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -71,7 +71,10 @@ const web = {
 
     const enableServerTiming = process.env.SIGNALFX_SERVER_TIMING_CONTEXT
     if (enableServerTiming && enableServerTiming.trim().toLowerCase() === 'true') {
-      res.setHeader('Server-Timing', traceParentHeader(span.context()))
+      if (!res._sfx_serverTimingAdded) {
+        res.setHeader('Server-Timing', traceParentHeader(span.context()))
+        res._sfx_serverTimingAdded = true
+      }
     }
 
     return callback && tracer.scope().activate(span, () => callback(span))

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -73,7 +73,7 @@ const web = {
     if (enableServerTiming && enableServerTiming.trim().toLowerCase() === 'true') {
       if (!res._sfx_serverTimingAdded) {
         res.setHeader('Server-Timing', traceParentHeader(span.context()))
-        res._sfx_serverTimingAdded = true
+        Object.defineProperty(res, '_sfx_serverTimingAdded', { value: true })
       }
     }
 


### PR DESCRIPTION
If SIGNALFX_SERVER_TIMING_CONTEXT is turned on, pass trace context
in traceparent form over a Server-Timing header.

https://www.w3.org/TR/server-timing/
https://www.w3.org/TR/trace-context/#traceparent-header