### PR TITLE
Added `withDisabledScope()` method to tracer

### DIFF
--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -21,6 +21,10 @@ class NoopTracer extends Tracer {
     this._span = new Span(this)
   }
 
+  withNonReportingScope (callback) {
+    return callback()
+  }
+
   trace (name, options, fn) {
     return fn(this._span, () => {})
   }

--- a/src/opentracing/nonreporting_span.js
+++ b/src/opentracing/nonreporting_span.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const platform = require('../platform')
+const Span = require('./span')
+const SpanContext = require('./nonreporting_span_context')
+
+class SignalFxNonReportingSpan extends Span {
+  _createContext (_) {
+    const spanId = platform.id()
+    const spanContext = new SpanContext({
+      traceId: spanId,
+      spanId
+    })
+    return spanContext
+  }
+
+  _finish (finishTime) {
+    if (this._duration !== undefined) {
+      return
+    }
+
+    finishTime = parseFloat(finishTime) || platform.now()
+    this._duration = finishTime - this._startTime
+    this._spanContext._isFinished = true
+    this._handle.finish()
+  }
+}
+
+module.exports = SignalFxNonReportingSpan

--- a/src/opentracing/nonreporting_span_context.js
+++ b/src/opentracing/nonreporting_span_context.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const SpanContext = require('./span_context')
+
+class SignalFxNonReportingSpanContext extends SpanContext {
+}
+
+module.exports = SignalFxNonReportingSpanContext

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -4,7 +4,9 @@ const opentracing = require('opentracing')
 const Tracer = opentracing.Tracer
 const Reference = opentracing.Reference
 const Span = require('./span')
+const NonReportingSpan = require('./nonreporting_span')
 const SpanContext = require('./span_context')
+const NonReportingSpanContext = require('./nonreporting_span_context')
 const Writer = require('../writer')
 const ZipkinV2Writer = require('../zipkin/writer')
 const Recorder = require('../recorder')
@@ -69,6 +71,12 @@ class SignalFxTracer extends Tracer {
     const type = reference && reference.type()
     const parent = reference && reference.referencedContext()
     const noopSpan = this._noopSpan
+
+    if (parent instanceof NonReportingSpan || parent instanceof NonReportingSpanContext) {
+      return new NonReportingSpan(this, this._recorder, this._sampler, this._prioritySampler, {
+        operationName: fields.operationName || 'nonReportingSFXSpan'
+      })
+    }
 
     if (type === REFERENCE_NOOP) return noopSpan
     if (parent && parent === noopSpan.context()) return noopSpan

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -73,6 +73,10 @@ class Tracer extends BaseTracer {
     return this
   }
 
+  withNonReportingScope (callback) {
+    return this._tracer.withNonReportingScope(callback)
+  }
+
   use () {
     this._instrumenter.use.apply(this._instrumenter, arguments)
     return this

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Tracer = require('./opentracing/tracer')
+const NonReportingSpan = require('./opentracing/nonreporting_span')
 const tags = require('../ext/tags')
 
 const SPAN_TYPE = tags.SPAN_TYPE
@@ -25,6 +26,15 @@ class SignalFxTracer extends Tracer {
 
     this._scopeManager = new ScopeManager()
     this._scope = new Scope()
+  }
+
+  withNonReportingScope (callback) {
+    const span = new NonReportingSpan(this, this._recorder, this._sampler, this._prioritySampler, {
+      operationName: 'nonReportingSFXSpan'
+    })
+    return this.scope().activate(span, () => {
+      return callback()
+    })
   }
 
   trace (name, options, fn) {

--- a/test/opentracing/nonreporting_span.spec.js
+++ b/test/opentracing/nonreporting_span.spec.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const Uint64BE = require('int64-buffer').Uint64BE
+
+describe('NonReportingSpan', () => {
+  let Span
+  let span
+  let tracer
+  let recorder
+  let prioritySampler
+  let sampler
+  let platform
+  let handle
+
+  beforeEach(() => {
+    handle = { finish: sinon.spy() }
+    platform = {
+      id: sinon.stub(),
+      metrics: sinon.stub().returns({
+        track: sinon.stub().returns(handle)
+      })
+    }
+    platform.id.onFirstCall().returns(new Uint64BE(123, 123))
+    platform.id.onSecondCall().returns(new Uint64BE(456, 456))
+
+    tracer = {}
+
+    sampler = {
+      rate: sinon.stub().returns(1)
+    }
+
+    recorder = {
+      record: sinon.stub()
+    }
+
+    prioritySampler = {
+      sample: sinon.stub()
+    }
+
+    Span = proxyquire('../src/opentracing/nonreporting_span', {
+      '../platform': platform
+    })
+  })
+
+  it('should have a default context', () => {
+    span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+
+    expect(span.context()._traceId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context()._spanId).to.deep.equal(new Uint64BE(123, 123))
+  })
+
+  it('should not use a parent context', () => {
+    const parent = {
+      _traceId: new Uint64BE(555, 555),
+      _spanId: new Uint64BE(666, 66),
+      _baggageItems: { foo: 'bar' },
+      _trace: {
+        started: ['span'],
+        finished: [],
+        origin: 'synthetics'
+      }
+    }
+
+    span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation', parent })
+
+    expect(span.context()._traceId).to.deep.equal(new Uint64BE(123, 123))
+    expect(span.context()._parentId).to.deep.equal(null)
+    expect(span.context()._baggageItems).to.deep.not.equal({ foo: 'bar' })
+    expect(span.context()._trace).to.not.equal(parent._trace)
+  })
+
+  describe('finish', () => {
+    it('should not add itself to the context trace finished spans', () => {
+      recorder.record.returns(Promise.resolve())
+
+      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+      span.finish()
+
+      expect(span.context()._trace.finished).to.deep.equal([])
+    })
+
+    it('should not record the span', () => {
+      recorder.record.returns(Promise.resolve())
+
+      span = new Span(tracer, recorder, sampler, prioritySampler, { operationName: 'operation' })
+      span.finish()
+
+      expect(recorder.record).to.have.been.callCount(0)
+    })
+  })
+})

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -16,6 +16,7 @@ describe('TracerProxy', () => {
   beforeEach(() => {
     tracer = {
       use: sinon.stub().returns('tracer'),
+      withNonReportingScope: sinon.stub().returns('result'),
       trace: sinon.stub().returns('test'),
       wrap: sinon.stub().returns('fn'),
       startSpan: sinon.stub().returns('span'),
@@ -28,6 +29,7 @@ describe('TracerProxy', () => {
 
     noop = {
       use: sinon.stub().returns('tracer'),
+      withNonReportingScope: sinon.stub().returns('result'),
       trace: sinon.stub().returns('test'),
       wrap: sinon.stub().returns('fn'),
       startSpan: sinon.stub().returns('span'),
@@ -238,6 +240,16 @@ describe('TracerProxy', () => {
         expect(returnValue).to.equal('flush')
       })
     })
+
+    describe('withNonReportingScope', () => {
+      it('should ignore with NoopTracer', () => {
+        const callback = () => 'result'
+        const returnValue = proxy.withNonReportingScope(callback)
+
+        expect(noop.withNonReportingScope).to.have.been.calledWith(callback)
+        expect(returnValue).to.equal('result')
+      })
+    })
   })
 
   describe('initialized', () => {
@@ -251,6 +263,16 @@ describe('TracerProxy', () => {
 
         expect(instrumenter.use).to.have.been.calledWith('a', 'b', 'c')
         expect(returnValue).to.equal(proxy)
+      })
+    })
+
+    describe('withNonReportingScope', () => {
+      it('should create disabled scope span', () => {
+        const callback = () => 'result'
+        const returnValue = proxy.withNonReportingScope(callback)
+
+        expect(tracer.withNonReportingScope).to.have.been.calledWith(callback)
+        expect(returnValue).to.equal('result')
       })
     })
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Span = require('opentracing').Span
+const NonReportingSpan = require('../src/opentracing/nonreporting_span')
 const Config = require('../src/config')
 const tags = require('../ext/tags')
 
@@ -32,6 +33,18 @@ describe('Tracer', () => {
     })
 
     tracer = new Tracer(config)
+  })
+
+  describe('withNonReportingScope', () => {
+    it('should create disabled spans inside the scope', () => {
+      const result = tracer.withNonReportingScope(() => {
+        tracer.trace('name', {}, span => {
+          expect(span).to.be.instanceof(NonReportingSpan)
+        })
+        return '1234'
+      })
+      expect(result).to.equal('1234')
+    })
   })
 
   describe('trace', () => {


### PR DESCRIPTION
This method allows users to entirely disable tracing within a given
scope. It accepts a single callback function and ensures any operations
taking places within that callback function will not be traced.

This is useful to disable tracing for certain code paths. For example,
SignalFx tracing/metrics libraries can wrap their network operations
with this method to ensure they don't generate spans for their own
ingest operations.

Implementation:

It introduce the following two new classes:

- DisabledSpan
- DisabledSpanContext

The DisabledSpan acts just like a regular span with the following
diffences:

1. It creates an instance of DisabledSpanContext instead of SpanContext.
2. It does not report itself to the tracer or recorder ever. This means
   the spans is never recorded and exported by the tracer.

- The newly introduced `tracer.withDisabledScope()` method creates a new
`DisabledSpan` instance and sets it as the active span in the scope.
- When the tracer asked to create a new span, it looks at the active
span and if the active span is an instance of the DisbaledSpan, it'll
create a new DisbaledSpan. If the parent is a regular span, then it'll
create a regular span as well preserving current behavior.

This way an enitre code path can be exluded from tracing without having
to modify application or library code executed in that code path.