### PR TITLE
Prevent span export path from being traced

### DIFF
--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -43,7 +43,7 @@ class SignalFxTracer extends Tracer {
     this._prioritySampler = new PrioritySampler(config.env)
     if (config.zipkin) {
       this._writer = new ZipkinV2Writer(
-        this._prioritySampler, config.url, config.path, config.headers
+        this._prioritySampler, config.url, config.path, config.headers, this
       )
     } else {
       this._writer = new Writer(this._prioritySampler, config.url)
@@ -130,6 +130,15 @@ class SignalFxTracer extends Tracer {
       return Promise.resolve()
     }
     return flushed
+  }
+
+  withNonReportingScope (callback) {
+    const span = new NonReportingSpan(this, this._recorder, this._sampler, this._prioritySampler, {
+      operationName: 'nonReportingSFXSpan'
+    })
+    return this.scope().activate(span, () => {
+      return callback()
+    })
   }
 }
 

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Tracer = require('./opentracing/tracer')
-const NonReportingSpan = require('./opentracing/nonreporting_span')
 const tags = require('../ext/tags')
 
 const SPAN_TYPE = tags.SPAN_TYPE
@@ -26,15 +25,6 @@ class SignalFxTracer extends Tracer {
 
     this._scopeManager = new ScopeManager()
     this._scope = new Scope()
-  }
-
-  withNonReportingScope (callback) {
-    const span = new NonReportingSpan(this, this._recorder, this._sampler, this._prioritySampler, {
-      operationName: 'nonReportingSFXSpan'
-    })
-    return this.scope().activate(span, () => {
-      return callback()
-    })
   }
 
   trace (name, options, fn) {


### PR DESCRIPTION
We use a URL based filter function to avoid tracing outgoing requests to
the the trace export endpoint but this is unreliable as some times the
server can redirect the client to a different URL or port. We already
have built mechanism to prevent tracing certain code paths that we use
in the metrics library. This commit uses the same mechanism to prevent
tracing the span export code path as well.