### PR TITLE
Improve correlating logs with spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Configure these options as parameters for the `init()` method or as environment 
 | accessToken             | SIGNALFX_ACCESS_TOKEN               |           | The optional organization access token for trace submission requests |
 | enabled                 | SIGNALFX_TRACING_ENABLED            | true      | Whether to enable the tracer. |
 | debug                   | SIGNALFX_TRACING_DEBUG              | false     | Enable debug logging in the tracer. |
-| logInjection            | SIGNALFX_LOGS_INJECTION             | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
 | tags                    | SIGNALFX_SPAN_TAGS                  | {}        | Set global tags that should be applied to all spans. Format for the environment variable is `key1:val1,key2:val2`. |
+| logInjection            | SIGNALFX_LOGS_INJECTION             | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
+| logInjectionTags        | SIGNALFX_LOG_INJECTION_TAGS         | ['service.name'] | If log injection is on, these tags will be injected to log context. |
 | flushInterval           |                                     | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | plugins                 |                                     | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | recordedValueMaxLength  | SIGNALFX_RECORDED_VALUE_MAX_LENGTH  | 1200      | Maximum length an attribute value can have. Values longer than this limit are truncated. Any negative value turns off truncation. |
@@ -151,6 +152,35 @@ ID log injection with this environment variable:
 
 ```bash
 $ SIGNALFX_LOGS_INJECTION=true
+```
+
+### Inject span tags into logs
+
+If log injection is enabled, in addition to trace ID and span ID, span tags can
+be injected to logs. By default only `service.name` is injected. To select which
+tags to inject, add `logInjectionTags` to init config:
+
+```javascript
+const tracer = require('signalfx-tracing').init({
+  tags: {environment: 'production', region: 'eu'},
+  // Only 'region' will be added to logs besides trace_id, and span_id
+  logInjectionTags: ['region']
+})
+```
+
+After which your logger will receive:
+```json
+signalfx: {
+  trace_id: <trace_id>,
+  span_id: <span_id>,
+  region: 'eu'
+}
+```
+
+Or set the same injected tag via an environment var:
+
+```bash
+$ SIGNALFX_LOG_INJECTION_TAGS=region
 ```
 
 ### Inject trace IDs with a custom logger

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Configure these options as parameters for the `init()` method or as environment 
 | debug                   | SIGNALFX_TRACING_DEBUG              | false     | Enable debug logging in the tracer. |
 | tags                    | SIGNALFX_SPAN_TAGS                  | {}        | Set global tags that should be applied to all spans. Format for the environment variable is `key1:val1,key2:val2`. |
 | logInjection            | SIGNALFX_LOGS_INJECTION             | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| logInjectionTags        | SIGNALFX_LOG_INJECTION_TAGS         | ['service.name'] | If log injection is on, these tags will be injected to log context. |
+| logInjectionTags        | SIGNALFX_LOGS_INJECTION_TAGS         | ['service.name'] | If log injection is on, these tags will be injected to log context. |
 | flushInterval           |                                     | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | plugins                 |                                     | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | recordedValueMaxLength  | SIGNALFX_RECORDED_VALUE_MAX_LENGTH  | 1200      | Maximum length an attribute value can have. Values longer than this limit are truncated. Any negative value turns off truncation. |
@@ -177,10 +177,10 @@ signalfx: {
 }
 ```
 
-Or set the same injected tag via an environment var:
+Or set the same injected tag via an environment var (with environment vars taking precendence):
 
 ```bash
-$ SIGNALFX_LOG_INJECTION_TAGS=region
+$ SIGNALFX_LOGS_INJECTION_TAGS=region
 ```
 
 ### Inject trace IDs with a custom logger

--- a/src/config.js
+++ b/src/config.js
@@ -75,8 +75,8 @@ class Config {
       }
     }
 
-    if (process.env.SIGNALFX_LOG_INJECTION_TAGS) {
-      for (const tag of process.env.SIGNALFX_LOG_INJECTION_TAGS.split(',')) {
+    if (process.env.SIGNALFX_LOGS_INJECTION_TAGS) {
+      for (const tag of process.env.SIGNALFX_LOGS_INJECTION_TAGS.split(',')) {
         if (tag.trim().length !== 0) {
           this.logInjectionTags.add(tag.trim())
         }

--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,7 @@ class Config {
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.logInjection = String(logInjection) === 'true'
+    this.logInjectionTags = new Set(coalesce(options.logInjectionTags, ['service.name']))
     this.env = env
     this.url = url ? new URL(url) : new URL(`${protocol}://${hostname}:${port}${path}`)
     this.zipkin = zipkin
@@ -70,6 +71,14 @@ class Config {
         const kv = segment.split(':')
         if (kv.length === 2 && kv[0].trim().length !== 0 && kv[1].trim().length !== 0) {
           this.tags[kv[0].trim()] = kv[1].trim()
+        }
+      }
+    }
+
+    if (process.env.SIGNALFX_LOG_INJECTION_TAGS) {
+      for (const tag of process.env.SIGNALFX_LOG_INJECTION_TAGS.split(',')) {
+        if (tag.trim().length !== 0) {
+          this.logInjectionTags.add(tag.trim())
         }
       }
     }

--- a/src/noop/tracer.js
+++ b/src/noop/tracer.js
@@ -19,6 +19,7 @@ class NoopTracer extends Tracer {
     this._scopeManager = new ScopeManager()
     this._scope = new Scope()
     this._span = new Span(this)
+    this._logInjectionTags = new Set()
   }
 
   withNonReportingScope (callback) {
@@ -51,6 +52,10 @@ class NoopTracer extends Tracer {
 
   flush () {
     return Promise.resolve()
+  }
+
+  logInjectionTags () {
+    return this._logInjectionTags
   }
 }
 

--- a/src/opentracing/tracer.js
+++ b/src/opentracing/tracer.js
@@ -39,6 +39,7 @@ class SignalFxTracer extends Tracer {
     this._env = config.env
     this._tags = config.tags
     this._logInjection = config.logInjection
+    this._logInjectionTags = config.logInjectionTags
     this._analytics = config.analytics
     this._prioritySampler = new PrioritySampler(config.env)
     if (config.zipkin) {
@@ -139,6 +140,10 @@ class SignalFxTracer extends Tracer {
     return this.scope().activate(span, () => {
       return callback()
     })
+  }
+
+  logInjectionTags () {
+    return this._logInjectionTags
   }
 }
 

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -2,6 +2,16 @@
 
 const tx = require('./tx')
 
+function injectedTags (tracer, span) {
+  const tags = {}
+
+  for (const key of tracer.logInjectionTags()) {
+    tags[key] = span.context()._tags[key]
+  }
+
+  return tags
+}
+
 const log = {
   // Add trace identifiers from the current scope to a log record.
   correlate (tracer, record) {
@@ -10,10 +20,10 @@ const log = {
     if (!span) return record
 
     return Object.assign({}, record, {
-      signalfx: {
+      signalfx: Object.assign(injectedTags(tracer, span), {
         trace_id: span.context().toTraceIdHex(),
         span_id: span.context().toSpanIdHex()
-      }
+      })
     })
   }
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -146,6 +146,10 @@ class Tracer extends BaseTracer {
   flush () {
     return this._tracer.flush.apply(this._tracer, arguments)
   }
+
+  logInjectionTags () {
+    return this._tracer.logInjectionTags.apply(this._tracer, arguments)
+  }
 }
 
 module.exports = Tracer

--- a/test/plugins/bunyan.spec.js
+++ b/test/plugins/bunyan.spec.js
@@ -70,7 +70,8 @@ describe('Plugin', () => {
 
             expect(record).to.have.deep.property('signalfx', {
               trace_id: span.context().toTraceIdHex(),
-              span_id: span.context().toSpanIdHex()
+              span_id: span.context().toSpanIdHex(),
+              'service.name': tracer._tracer._service
             })
           })
         })

--- a/test/plugins/pino.spec.js
+++ b/test/plugins/pino.spec.js
@@ -57,6 +57,7 @@ describe('Plugin', () => {
       describe('with configuration', () => {
         beforeEach(() => {
           tracer._tracer._logInjection = true
+          tracer._tracer._logInjectionTags.clear()
           setup(version)
         })
 

--- a/test/plugins/winston.spec.js
+++ b/test/plugins/winston.spec.js
@@ -79,7 +79,8 @@ describe('Plugin', () => {
           const meta = {
             signalfx: {
               trace_id: span.context().toTraceIdHex(),
-              span_id: span.context().toSpanIdHex()
+              span_id: span.context().toSpanIdHex(),
+              'service.name': tracer._tracer._service
             }
           }
 


### PR DESCRIPTION
While previously `trace_id` and `span_id` were injected into log parameters, this PR adds an additional option to inject additional span tags to log context in somewhat a similar way as is in https://github.com/signalfx/splunk-otel-java#correlating-traces-with-logs

This will only happen if log injection is enabled. By default only `service.name` will be injected besides trace and span IDs. The injected tags can be selected with `logInjectionTags` configuration parameter - the README section contains an example.