### PR TITLE
Make logs injection more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Configure these options as parameters for the `init()` method or as environment 
 | debug                   | SIGNALFX_TRACING_DEBUG              | false     | Enable debug logging in the tracer. |
 | tags                    | SIGNALFX_SPAN_TAGS                  | {}        | Set global tags that should be applied to all spans. Format for the environment variable is `key1:val1,key2:val2`. |
 | logInjection            | SIGNALFX_LOGS_INJECTION             | false     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| logInjectionTags        | SIGNALFX_LOGS_INJECTION_TAGS         | ['service.name'] | If log injection is on, these tags will be injected to log context. |
+| logInjectionTags        | SIGNALFX_LOGS_INJECTION_TAGS         | ['environment'] | If log injection is on, these tags will be injected to log context. |
 | flushInterval           |                                     | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | plugins                 |                                     | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | recordedValueMaxLength  | SIGNALFX_RECORDED_VALUE_MAX_LENGTH  | 1200      | Maximum length an attribute value can have. Values longer than this limit are truncated. Any negative value turns off truncation. |
@@ -141,30 +141,30 @@ the `span.context`:
 ```json
 signalfx: {
   trace_id: <trace_id>,
-  span_id: <span_id>      
+  span_id: <span_id>,
+  service: <service name>,
+  environment: <environment tag>
 }
 ```
 
-### Inject trace IDs with Bunyan, Pino, or Winston
+### Inject trace information with Bunyan, Pino, or Winston
 
-To transfer trace context to logs with Bunyan, Pino, or Winston, enable trace
-ID log injection with this environment variable:
+To transfer trace context (trace ID, span ID, service name, environment) to logs with Bunyan, Pino, or Winston, enable log injection with this environment variable:
 
 ```bash
 $ SIGNALFX_LOGS_INJECTION=true
 ```
 
-### Inject span tags into logs
+### Inject additional span tags into log context
 
 If log injection is enabled, in addition to trace ID and span ID, span tags can
-be injected to logs. By default only `service.name` is injected. To select which
-tags to inject, add `logInjectionTags` to init config:
+be injected to logs. To select which tags to inject, add `logInjectionTags` to init config, by default only
+`environment` is injected:
 
 ```javascript
 const tracer = require('signalfx-tracing').init({
   tags: {environment: 'production', region: 'eu'},
-  // Only 'region' will be added to logs besides trace_id, and span_id
-  logInjectionTags: ['region']
+  logInjectionTags: ['environment', 'region']
 })
 ```
 
@@ -173,6 +173,8 @@ After which your logger will receive:
 signalfx: {
   trace_id: <trace_id>,
   span_id: <span_id>,
+  service: <service name>
+  environment: 'production',
   region: 'eu'
 }
 ```
@@ -180,7 +182,7 @@ signalfx: {
 Or set the same injected tag via an environment var (with environment vars taking precendence):
 
 ```bash
-$ SIGNALFX_LOGS_INJECTION_TAGS=region
+$ SIGNALFX_LOGS_INJECTION_TAGS=environment,region
 ```
 
 ### Inject trace IDs with a custom logger

--- a/src/config.js
+++ b/src/config.js
@@ -45,7 +45,7 @@ class Config {
     this.enabled = String(enabled) === 'true'
     this.debug = String(debug) === 'true'
     this.logInjection = String(logInjection) === 'true'
-    this.logInjectionTags = new Set(coalesce(options.logInjectionTags, ['service.name']))
+    this.logInjectionTags = new Set(coalesce(options.logInjectionTags, ['environment']))
     this.env = env
     this.url = url ? new URL(url) : new URL(`${protocol}://${hostname}:${port}${path}`)
     this.zipkin = zipkin

--- a/src/plugins/util/log.js
+++ b/src/plugins/util/log.js
@@ -19,10 +19,13 @@ const log = {
 
     if (!span) return record
 
+    const context = span.context()
+
     return Object.assign({}, record, {
       signalfx: Object.assign(injectedTags(tracer, span), {
-        trace_id: span.context().toTraceIdHex(),
-        span_id: span.context().toSpanIdHex()
+        trace_id: context.toTraceIdHex(),
+        span_id: context.toSpanIdHex(),
+        service: context._tags['service.name']
       })
     })
   }

--- a/test/plugins/agent.js
+++ b/test/plugins/agent.js
@@ -94,7 +94,9 @@ module.exports = {
           service: 'test',
           url: `http://localhost:${port}/v1/trace`,
           flushInterval: 0,
-          plugins: false
+          plugins: false,
+          tags: { environment: 'test-env' },
+          logInjectionTags: ['environment']
         })
 
         for (let i = 0, l = pluginName.length; i < l; i++) {

--- a/test/plugins/bunyan.spec.js
+++ b/test/plugins/bunyan.spec.js
@@ -71,7 +71,8 @@ describe('Plugin', () => {
             expect(record).to.have.deep.property('signalfx', {
               trace_id: span.context().toTraceIdHex(),
               span_id: span.context().toSpanIdHex(),
-              'service.name': tracer._tracer._service
+              service: tracer._tracer._service,
+              environment: span.context()._tags['environment']
             })
           })
         })

--- a/test/plugins/pino.spec.js
+++ b/test/plugins/pino.spec.js
@@ -71,7 +71,8 @@ describe('Plugin', () => {
 
             expect(record).to.have.deep.property('signalfx', {
               trace_id: span.context().toTraceIdHex(),
-              span_id: span.context().toSpanIdHex()
+              span_id: span.context().toSpanIdHex(),
+              service: tracer._tracer._service
             })
           })
         })

--- a/test/plugins/util/log.spec.js
+++ b/test/plugins/util/log.spec.js
@@ -11,7 +11,8 @@ describe('plugins/util/log', () => {
       service: 'test',
       plugins: false,
       zipkin: false,
-      tags: { environment: 'prod' }
+      tags: { environment: 'test-env' },
+      logInjectionTags: []
     })
     log = require('../../../src/plugins/util/log')
   })
@@ -26,7 +27,7 @@ describe('plugins/util/log', () => {
         expect(record).to.have.deep.property('signalfx', {
           trace_id: span.context().toTraceIdHex(),
           span_id: span.context().toSpanIdHex(),
-          'service.name': 'test'
+          service: 'test'
         })
       })
     })
@@ -40,7 +41,7 @@ describe('plugins/util/log', () => {
         expect(record).to.have.deep.property('signalfx', {
           trace_id: span.context().toTraceIdHex(),
           span_id: span.context().toSpanIdHex(),
-          'service.name': 'test'
+          service: 'test'
         })
       })
     })
@@ -82,8 +83,8 @@ describe('plugins/util/log', () => {
         expect(record).to.have.deep.property('signalfx', {
           trace_id: span.context().toTraceIdHex(),
           span_id: span.context().toSpanIdHex(),
-          'service.name': 'test',
-          'environment': 'prod'
+          service: 'test',
+          environment: 'test-env'
         })
       })
     })

--- a/test/plugins/winston.spec.js
+++ b/test/plugins/winston.spec.js
@@ -80,7 +80,7 @@ describe('Plugin', () => {
             signalfx: {
               trace_id: span.context().toTraceIdHex(),
               span_id: span.context().toSpanIdHex(),
-              'service.name': tracer._tracer._service
+              service: tracer._tracer._service
             }
           }
 


### PR DESCRIPTION
* Service name is now always injected into log context if injection is enabled.
* Renamed `service.name` in logs to `service` to be in line with other agents.
* By default `environment` tag is now injected to logs as well.