### PR TITLE
Perf improvements

### DIFF
--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -195,16 +195,17 @@ function hasAmazonSignature (options) {
 
   if (options.headers) {
     const headers = Object.keys(options.headers)
-      .reduce((prev, next) => Object.assign(prev, {
-        [next.toLowerCase()]: options.headers[next]
-      }), {})
 
-    if (headers['x-amz-signature']) {
-      return true
-    }
+    for (let i = 0; i < headers.length; i++) {
+      const header = headers[i].toLowerCase()
 
-    if ([].concat(headers['authorization']).some(startsWith('AWS4-HMAC-SHA256'))) {
-      return true
+      if (header === 'x-amz-signature') {
+        return true
+      }
+
+      if (header === 'authorization' && String(options.headers[header]).startsWith('AWS4-HMAC-SHA256')) {
+        return true
+      }
     }
   }
 

--- a/src/plugins/http/client.js
+++ b/src/plugins/http/client.js
@@ -203,7 +203,7 @@ function hasAmazonSignature (options) {
         return true
       }
 
-      if (header === 'authorization' && String(options.headers[header]).startsWith('AWS4-HMAC-SHA256')) {
+      if (header === 'authorization' && hasAmazonHmac([].concat(options.headers[headers[i]]))) {
         return true
       }
     }
@@ -212,8 +212,16 @@ function hasAmazonSignature (options) {
   return options.path && options.path.toLowerCase().indexOf('x-amz-signature=') !== -1
 }
 
-function startsWith (searchString) {
-  return value => String(value).startsWith(searchString)
+function hasAmazonHmac (fields) {
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
+
+    if (typeof field === 'string' && field.startsWith('AWS4-HMAC-SHA256')) {
+      return true
+    }
+  }
+
+  return false
 }
 
 function unpatch (http) {

--- a/src/plugins/util/host.js
+++ b/src/plugins/util/host.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = {
+  isHostName (name) {
+    if (typeof name !== 'string') {
+      return false
+    }
+
+    let noColon = true
+    let hasHostChar = false
+
+    for (let i = 0; i < Math.min(name.length, 5); i++) {
+      const c = name.charCodeAt(i)
+
+      // ':'
+      if (c === 58) {
+        noColon = false
+        break
+      }
+
+      // 'a' to 'z' or 'A' to 'Z' or '-'
+      if ((c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c === 45) {
+        hasHostChar = true
+      }
+    }
+
+    return hasHostChar && noColon
+  }
+}

--- a/src/plugins/util/host.js
+++ b/src/plugins/util/host.js
@@ -6,7 +6,6 @@ module.exports = {
       return false
     }
 
-    let noColon = true
     let hasHostChar = false
 
     for (let i = 0; i < Math.min(name.length, 5); i++) {
@@ -14,8 +13,7 @@ module.exports = {
 
       // ':'
       if (c === 58) {
-        noColon = false
-        break
+        return false
       }
 
       // 'a' to 'z' or 'A' to 'Z' or '-'
@@ -24,6 +22,6 @@ module.exports = {
       }
     }
 
-    return hasHostChar && noColon
+    return hasHostChar
   }
 }

--- a/src/plugins/util/tx.js
+++ b/src/plugins/util/tx.js
@@ -1,19 +1,24 @@
 'use strict'
 
 const ipaddr = require('ipaddr.js')
+const isHostName = require('./host.js').isHostName
 
 const tx = {
   // Set the outgoing host by its deduced kind
   setHost (span, hostname, port) {
-    try {
-      const parsed = ipaddr.parse(hostname)
-      if (parsed.kind() === 'ipv4') {
-        span.setTag('peer.ipv4', hostname)
-      } else {
-        span.setTag('peer.ipv6', hostname)
+    if (isHostName(hostname)) {
+      span.setTag('peer.hostname', hostname)
+    } else {
+      try {
+        const parsed = ipaddr.parse(hostname)
+        if (parsed.kind() === 'ipv4') {
+          span.setTag('peer.ipv4', hostname)
+        } else {
+          span.setTag('peer.ipv6', hostname)
+        }
+      } catch (e) {
+        hostname && span.setTag('peer.hostname', hostname)
       }
-    } catch (e) {
-      hostname && span.setTag('peer.hostname', hostname)
     }
     port && span.setTag('peer.port', port)
   },

--- a/test/plugins/util/host.spec.js
+++ b/test/plugins/util/host.spec.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const isHostName = require('../../../src/plugins/util/host').isHostName
+
+describe('plugins/utils/host', () => {
+  describe('isHostName', () => {
+    it('should return true for valid host names', () => {
+      const hosts = [
+        'example.com',
+        'localhost',
+        'en.wikipedia.org',
+        '1.a.com',
+        '0-1.test',
+        '0-a.c.y',
+        'xn--hxa'
+      ]
+
+      hosts.forEach((name) => expect(isHostName(name)).to.be.true)
+    })
+
+    it('should return false for ipv4', () => {
+      const hosts = [
+        '0.0.0.0',
+        '01.02.03.04',
+        '127.0.0.1',
+        '127.000.000.001',
+        '192.168.1.2',
+        '255.255.255.255'
+      ]
+
+      hosts.forEach((name) => expect(isHostName(name)).to.be.false)
+    })
+
+    it('should return false for ipv6', () => {
+      const hosts = [
+        '::',
+        '::1',
+        '1::',
+        'ff0X::1',
+        'ff02::1',
+        '::1234:5678',
+        '2001:0db7:0002:0000:0000:0ab9:C0A9:0103'
+      ]
+
+      hosts.forEach((name) => expect(isHostName(name)).to.be.false)
+    })
+
+    it('should return false for jank', () => {
+      const hosts = [
+        null,
+        undefined,
+        NaN,
+        true,
+        1234,
+        {},
+        [],
+        '',
+        ' '
+      ]
+
+      hosts.forEach((name) => expect(isHostName(name)).to.be.false)
+    })
+  })
+})


### PR DESCRIPTION
Speed up `tx.setHost` by not throwing on IP address parsing when the given name is a host name. This caused significant overhead when the input is a host name - an exception is thrown and caught in 100% of the cases and when doing multiple outgoing HTTP calls, can add up quickly.

Also a minor perf improvement from simplifying `hasAmazonSignature`, found via profiling.