### PR TITLE
Add Server-Timing injection doc, enable it as a config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Configure these options as parameters for the `init()` method or as environment 
 | flushInterval           |                                     | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | plugins                 |                                     | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | recordedValueMaxLength  | SIGNALFX_RECORDED_VALUE_MAX_LENGTH  | 1200      | Maximum length an attribute value can have. Values longer than this limit are truncated. Any negative value turns off truncation. |
+| enableServerTiming      | SIGNALFX_SERVER_TIMING_CONTEXT      | false     | Enable injection of `Server-Timing` response header containing the current trace (e.g. `Server-Timing: traceparent;desc="00-traceId-spanId-01"`). |
 
 ### Steps
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Configure these options as parameters for the `init()` method or as environment 
 | flushInterval           |                                     | 2000      | Interval in milliseconds at which the tracer will submit traces to the agent. |
 | plugins                 |                                     | true      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
 | recordedValueMaxLength  | SIGNALFX_RECORDED_VALUE_MAX_LENGTH  | 1200      | Maximum length an attribute value can have. Values longer than this limit are truncated. Any negative value turns off truncation. |
-| enableServerTiming      | SIGNALFX_SERVER_TIMING_CONTEXT      | false     | Enable injection of `Server-Timing` response header containing the current trace (e.g. `Server-Timing: traceparent;desc="00-traceId-spanId-01"`). |
+| enableServerTiming      | SIGNALFX_SERVER_TIMING_CONTEXT      | true      | Enable injection of `Server-Timing` response header containing the current trace (e.g. `Server-Timing: traceparent;desc="00-traceId-spanId-01"`). |
 
 ### Steps
 

--- a/src/config.js
+++ b/src/config.js
@@ -96,8 +96,22 @@ class Config {
     this.experimental = {}
 
     this.enableServerTiming =
-      String(coalesce(options.enableServerTiming, platform.env('SIGNALFX_SERVER_TIMING_CONTEXT'), false)) === 'true'
+      coalesce(options.enableServerTiming, booleanEnvVar('SIGNALFX_SERVER_TIMING_CONTEXT'), true)
   }
+}
+
+function booleanEnvVar (key) {
+  const value = platform.env(key)
+
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  if (['false', 'no', '0'].indexOf(value.trim().toLowerCase()) >= 0) {
+    return false
+  }
+
+  return true
 }
 
 module.exports = Config

--- a/src/config.js
+++ b/src/config.js
@@ -94,6 +94,9 @@ class Config {
     }
     this.runtimeMetrics = String(runtimeMetrics) === 'true'
     this.experimental = {}
+
+    this.enableServerTiming =
+      String(coalesce(options.enableServerTiming, platform.env('SIGNALFX_SERVER_TIMING_CONTEXT'), false)) === 'true'
   }
 }
 

--- a/src/plugins/util/web.js
+++ b/src/plugins/util/web.js
@@ -69,8 +69,7 @@ const web = {
     wrapEnd(req)
     wrapEvents(req)
 
-    const enableServerTiming = process.env.SIGNALFX_SERVER_TIMING_CONTEXT
-    if (enableServerTiming && enableServerTiming.trim().toLowerCase() === 'true') {
+    if (config.enableServerTiming) {
       if (!res._sfx_serverTimingAdded) {
         res.setHeader('Server-Timing', traceParentHeader(span.context()))
         res.setHeader('Access-Control-Expose-Headers', 'Server-Timing')

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -35,6 +35,7 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
     expect(config).to.have.property('recordedValueMaxLength', 1200)
+    expect(config).to.have.property('enableServerTiming', false)
   })
 
   it('should initialize from the default service', () => {
@@ -52,6 +53,7 @@ describe('Config', () => {
     platform.env.withArgs('SIGNALFX_SERVICE_NAME').returns('service')
     platform.env.withArgs('SIGNALFX_ENV').returns('test')
     platform.env.withArgs('SIGNALFX_RECORDED_VALUE_MAX_LENGTH').returns('1201')
+    platform.env.withArgs('SIGNALFX_SERVER_TIMING_CONTEXT').returns('true')
 
     const config = new Config()
 
@@ -65,6 +67,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'service')
     expect(config).to.have.property('env', 'test')
     expect(config).to.have.property('recordedValueMaxLength', 1201)
+    expect(config).to.have.property('enableServerTiming', true)
   })
 
   it('should initialize from environment variables with url taking precedence', () => {
@@ -189,6 +192,7 @@ describe('Config', () => {
     platform.env.withArgs('SIGNALFX_ENV').returns('test')
     platform.env.withArgs('SIGNALFX_RUNTIME_METRICS_ENABLED').returns('true')
     platform.env.withArgs('SIGNALFX_RECORDED_VALUE_MAX_LENGTH').returns('1203')
+    platform.env.withArgs('SIGNALFX_SERVER_TIMING_CONTEXT').returns('true')
 
     const config = new Config('test', {
       enabled: true,
@@ -203,7 +207,8 @@ describe('Config', () => {
       runtimeMetrics: false,
       service: 'test',
       env: 'development',
-      recordedValueMaxLength: 1204
+      recordedValueMaxLength: 1204,
+      enableServerTiming: false
     })
 
     expect(config).to.have.property('enabled', true)
@@ -217,6 +222,7 @@ describe('Config', () => {
     expect(config).to.have.property('service', 'test')
     expect(config).to.have.property('env', 'development')
     expect(config).to.have.property('recordedValueMaxLength', 1204)
+    expect(config).to.have.property('enableServerTiming', false)
   })
 
   it('should give priority to the options especially url', () => {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -35,7 +35,7 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', true)
     expect(config).to.have.property('env', undefined)
     expect(config).to.have.property('recordedValueMaxLength', 1200)
-    expect(config).to.have.property('enableServerTiming', false)
+    expect(config).to.have.property('enableServerTiming', true)
   })
 
   it('should initialize from the default service', () => {

--- a/test/plugins/util/web.spec.js
+++ b/test/plugins/util/web.spec.js
@@ -256,7 +256,7 @@ describe('plugins/util/web', () => {
 
       it('should set Server-Timing when configured', () => {
         try {
-          process.env.SIGNALFX_SERVER_TIMING_CONTEXT = 'true'
+          config.enableServerTiming = true
           web.instrument(tracer, config, req, res, 'test.request', span => {
             config.service = 'test2'
             web.instrument(tracer, config, req, res, 'test.request')
@@ -268,7 +268,7 @@ describe('plugins/util/web', () => {
             expect(res.setHeader.args[1][1]).to.equal('Server-Timing')
           })
         } finally {
-          delete process.env.SIGNALFX_SERVER_TIMING_CONTEXT
+          config.enableServerTiming = false
         }
       })
     })


### PR DESCRIPTION
* Update README for the `SIGNALFX_SERVER_TIMING_CONTEXT` field
* Make the same option available via configuration options
* Enable server-timing by default