### PR TITLE
Propagate server timing setting to instrumentor

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -42,7 +42,9 @@ class Instrumenter {
 
     const loadPlugin = (name, plugin) => {
       if (!this._plugins.has(plugin)) {
-        this._set(plugin, { name, config: {} })
+        this._set(plugin, { name, config: {
+          enableServerTiming: config.enableServerTiming,
+        } })
       }
     }
 


### PR DESCRIPTION
server timing setting was not being propagated to instrumentation
configuration. This patch propagates it from tracer config to
instrumenter config so each instrumentation can make a decision based on
the config option set by the user.